### PR TITLE
(Feature) PR and Issue templates

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 Before filing an issue, please provide the following information:
 
-- What is it? (leave one option)
+- **What is it?** (leave one option)
     * `(Bug)` report (i.e. something doesn't work as it should)
     * New `(Feature)` request (i.e. some nice-to-have feature is missing)
     * `(Improvement)` proposal (i.e. some existing feature can be improved)
@@ -8,11 +8,11 @@ Before filing an issue, please provide the following information:
 
 Please also put this into issue title, e.g. `(Bug) confirmation page not loading`
 
-- What problem have you encountered (provide steps to reproduce if possible) / What feature are you talking about?
+- **What problem have you encountered (provide steps to reproduce if possible) / What feature are you talking about?**
 
 
-- What is expected behaviour / What is proposed feature?
+- **What is expected behaviour / What is proposed feature?**
 
 
-- Additional information
+- **Additional information**
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,18 @@
+Before filing an issue, please provide the following information:
+
+- What is it? (leave one option)
+    * `(Bug)` report (i.e. something doesn't work as it should)
+    * New `(Feature)` request (i.e. some nice-to-have feature is missing)
+    * `(Improvement)` proposal (i.e. some existing feature can be improved)
+    * `(Refactor)` proposal (i.e. no new features or updates, just code optimization/library updates)
+
+Please also put this into issue title, e.g. `(Bug) confirmation page not loading`
+
+- What problem have you encountered (provide steps to reproduce if possible) / What feature are you talking about?
+
+
+- What is expected behaviour / What is proposed feature?
+
+
+- Additional information
+

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 Before submitting a pull request, please provide the following information:
 
-- What is it? (leave one option)
+- **What is it?** (leave one option)
     * Bug `(Fix)`
     * New `(Feature)` implementation
     * `(Improvement)` of existing functionality
@@ -8,19 +8,19 @@ Before submitting a pull request, please provide the following information:
 
 Please also put it into pull request title, e.g. `(Fix) confirmation page loading`
 
-- What was the root cause of the problem originally / what feature was missing?
+- **What was the root cause of the problem originally / what feature was missing?**
 
 
-- How does this pull request solve it (in broad terms)?
+- **How does this pull request solve it (in broad terms)?**
 
 
-- Does it close any open issues?
+- **Does it close any open issues?**
 Closes ...
 
 
-- Quick checklist
+- **Quick checklist**
     - [ ] docs were updated where necessary OR they don't need to be updated
     - [ ] tests were updated where necessary OR they don't need to be updated
 
-- Additional information
+- **Additional information**
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+Before submitting a pull request, please provide the following information:
+
+- What is it? (leave one option)
+    * Bug `(Fix)`
+    * New `(Feature)` implementation
+    * `(Improvement)` of existing functionality
+    * `(Refactor)` of existing code (no functionality change)
+
+Please also put it into pull request title, e.g. `(Fix) confirmation page loading`
+
+- What was the root cause of the problem originally / what feature was missing?
+
+
+- How does this pull request solve it (in broad terms)?
+
+
+- Does it close any open issues?
+Closes ...
+
+- Additional information

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,10 @@ Please also put it into pull request title, e.g. `(Fix) confirmation page loadin
 - Does it close any open issues?
 Closes ...
 
+
+- Quick checklist
+    - [ ] docs were updated where necessary OR they don't need to be updated
+    - [ ] tests were updated where necessary OR they don't need to be updated
+
 - Additional information
+


### PR DESCRIPTION
Add templates for new PR and new Issue (github will render them automatically)

Also I propose to use the following labels for PRs and Issues:

* based on scope
    * `scope-ui` for stuff related to css, logos, images, ...
    * `scope-dapp` for code of the dapp (general)
    * `scope-dapp-registration` for code of "register new address" step
    * `scope-dapp-confirmation` for code of "enter confirmation code" step
    * `scope-contract` for solidity contract code
    * `scope-contract-tests` for auto-tests of the contract
    * `scope-server-tests` for auto-tests of server api
    * `scope-server-api` for routes methods
    * `scope-server-lib` for various scripts used on backend
    * `scope-postoffice` for integration with post api
    * `scope-docs` for documentation (at the present moment, only README)

* based on priority
    * `priority-0` super urgent, drop everything else
    * `priority-high` asap
    * normal priority without a label
    * `priority-low` when done with everything else
    * `priority-cleaning` small fixes that are nice to have

I'll update existing open issues after this gets approved.