### PR TITLE
(Refactor) Move signature logic to function

### DIFF
--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -1,4 +1,19 @@
 const ProofOfPhysicalAddress = artifacts.require('ProofOfPhysicalAddress');
+const buildSignature = require('../../web-dapp/server-lib/buildSignature')
+
+// Private keys of accounts generated when running `npm run start-testrpc`
+const privateKeys = [
+  '68d90a98fc4b8e66a016f66cb8363904a4e521a2480602bd78cc67945676e9cd',
+  '1dd9083e16e190fa5413f87837025556063c546bf16e38cc53fd5d018a3acfbb',
+  'a2fbd494c3031335d595cc5ad89a9c97d3e5a7f6b00d191d91af915b8b039d34',
+  'ed8aa8f379bac1ff5eafc5f792c32b40a5419edf528a37addbfc8ce36c487463',
+  '81193e26e271a824fda36511b2814e9d47e0c16ebd31304e88c25a6d659286b8',
+  '6ee2f0da244d4eea41bd2d92eb8af046589956790ca83055d72d6cb3fe425a57',
+  'b66c237da44e8f9d4411fa9b15c6d6e2df81f93bc5f03430895ccb5cc0a6aff9',
+  '27d7d3598f704da770bb126df3f7b073809ce2ea8cd0d7b75a409e320bf31b05',
+  '9095ed8f4917235794b9c4fe9438fec29de759916bf216a8aa28f647664a35ff',
+  'ab470a1366c59dec4058af0110d6447addf1bad57965bff5b01059cbd80ac47f'
+]
 
 contract('ownership', (accounts) => {
   it('signer should be equal to owner', async () => {
@@ -13,7 +28,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should register an address', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs()
+      const args = buildRegisterAddressArgs(accounts[0])
 
       let addresses = await popa.total_addresses()
       assert.equal(+addresses, 0)
@@ -28,7 +43,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should fail if name is empty', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs({ name: '' })
+      const args = buildRegisterAddressArgs(accounts[0], { name: '' })
 
       await registerAddress(popa, args, accounts[0])
         .then(
@@ -44,7 +59,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should fail if country is empty', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs({ country: '' })
+      const args = buildRegisterAddressArgs(accounts[0], { country: '' })
 
       await registerAddress(popa, args, accounts[0])
         .then(
@@ -60,7 +75,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should fail if state is empty', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs({ state: '' })
+      const args = buildRegisterAddressArgs(accounts[0], { state: '' })
 
       await registerAddress(popa, args, accounts[0])
         .then(
@@ -76,7 +91,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should fail if city is empty', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs({ city: '' })
+      const args = buildRegisterAddressArgs(accounts[0], { city: '' })
 
       await registerAddress(popa, args, accounts[0])
         .then(
@@ -92,7 +107,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should fail if address is empty', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs({ location: '' })
+      const args = buildRegisterAddressArgs(accounts[0], { address: '' })
 
       await registerAddress(popa, args, accounts[0])
         .then(
@@ -108,7 +123,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should fail if zip code is empty', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs({ zip: '' })
+      const args = buildRegisterAddressArgs(accounts[0], { zip: '' })
 
       await registerAddress(popa, args, accounts[0])
         .then(
@@ -124,7 +139,7 @@ contract('address registration', function(accounts) {
   contract('', () => {
     it('register_address should fail if sent value is not enough', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs()
+      const args = buildRegisterAddressArgs(accounts[0])
 
       await registerAddress(popa, args, accounts[0], '39999999999999999')
         .then(
@@ -145,23 +160,29 @@ contract('address registration', function(accounts) {
  * 1dd9083e16e190fa5413f87837025556063c546bf16e38cc53fd5d018a3acfbb, for the requester address
  * 0x7e7693f12bfd372042b754b729d1474572a2dd01
  */
-function buildRegisterAddressArgs(extraArgs = {}) {
+function buildRegisterAddressArgs(account, extraArgs = {}) {
   const baseArgs = {
+    wallet: account,
     name: 'john doe',
     country: 'us',
     state: 'ca',
     city: 'san francisco',
-    location: '185 berry st',
+    address: '185 berry st',
     zip: '94107',
-    price_wei: '40000000000000000', // bignumber
-    confirmation_code: '8hwpyynkd9',
-    confirmation_code_sha3: '0x94db87942fb1d72ad3dc465491a87a85714fcd3c913dc496c7810667a3155d8a', // buffer
-    sig_v: '27', // bignumber
-    sig_r: '0x2562ce89c06b2d22a3a797031c64ab41bd3e89fa73b899c9e61d4da1ac3b47ca', // buffer
-    sig_s: '0x11606e611465ecdad3fb0e4276aca50c63bccb061d53fff78b5527600904e8ff' // buffer
+    price_wei: '40000000000000000',
+    cc: '8hwpyynkd9'
   }
 
-  return Object.assign(baseArgs, extraArgs)
+  const args = Object.assign(baseArgs, extraArgs)
+
+  args.sha3cc = web3.sha3(args.cc)
+
+  const { v, r, s } = buildSignature(args, privateKeys[1])
+  args.sig_v = v
+  args.sig_r = r
+  args.sig_s = s
+
+  return args
 }
 
 function registerAddress(popa, args, account, value = args.price_wei) {
@@ -170,10 +191,10 @@ function registerAddress(popa, args, account, value = args.price_wei) {
     args.country,
     args.state,
     args.city,
-    args.location,
+    args.address,
     args.zip,
     args.price_wei,
-    args.confirmation_code_sha3,
+    args.sha3cc,
     args.sig_v,
     args.sig_r,
     args.sig_s,

--- a/web-dapp/routes/index.js
+++ b/web-dapp/routes/index.js
@@ -10,7 +10,7 @@ module.exports = (opts) => {
     const router = express.Router();
     const files = fs
         .readdirSync(__dirname)
-        .filter(f => f !== 'index.js' && f[0] !== '_');
+        .filter(f => f !== 'index.js' && f[0] !== '_' && f[0] !== '.');
 
     logger.log('Found ' + files.length + ' route(s): ' + JSON.stringify(files));
     for (let f of files) {

--- a/web-dapp/routes/prepare_con_tx.js
+++ b/web-dapp/routes/prepare_con_tx.js
@@ -68,7 +68,7 @@ module.exports = (opts) => {
         logger.log(prelog + '=> text2sign: ' + text2sign);
 
         try {
-            var sign_output = sign(text2sign);
+            var sign_output = sign(text2sign, config.signer_private_key);
             logger.log(prelog + 'sign() output: ' + JSON.stringify(sign_output));
             return send_response(res, {
                 ok: true,

--- a/web-dapp/routes/prepare_reg_tx.js
+++ b/web-dapp/routes/prepare_reg_tx.js
@@ -165,17 +165,8 @@ module.exports = (opts) => {
 
             var session_key = Math.random();
             logger.log(prelog + 'setting session_key: ' + session_key);
-            db.set(
-                session_key,
-                { wallet, date: new Date(), confirmation_code_plain },
-                function(err) {
-                    if (err) {
-                        logger.error(prelog + 'error setting session_key: ' + err);
-                        return send_response(res, {
-                            ok: false,
-                            err: 'error setting session_key',
-                        });
-                    }
+            db.set(session_key, { wallet, date: new Date(), confirmation_code_plain })
+                .then(() => {
                     return send_response(res, {
                         ok: true,
                         result: {
@@ -188,8 +179,14 @@ module.exports = (opts) => {
                             session_key: session_key,
                         },
                     });
-                }
-            );
+                })
+                .catch(err => {
+                    logger.error(prelog + 'error setting session_key: ' + err);
+                    return send_response(res, {
+                        ok: false,
+                        err: 'error setting session_key',
+                    });
+                });
         });
     });
 

--- a/web-dapp/routes/prepare_reg_tx.js
+++ b/web-dapp/routes/prepare_reg_tx.js
@@ -3,7 +3,7 @@
 const logger = require('../server-lib/logger');
 const express = require('express');
 const config = require('../server-config');
-const sign = require('../server-lib/sign');
+const buildSignature = require('../server-lib/buildSignature');
 const generate_code = require('../server-lib/generate_code');
 const validate = require('../server-lib/validations').validate;
 const normalize = require('../server-lib/validations').normalize;
@@ -108,52 +108,18 @@ module.exports = (opts) => {
             logger.log(prelog + 'confirmation_code_plain: ' + confirmation_code_plain);
             var sha3cc = config.web3.sha3(confirmation_code_plain);
 
-            // convert parameters to buffers
-            var buf_params = {};
-            Object.keys(params).forEach(p => {
-                buf_params[p] = Buffer.from(params[p], 'utf8');
-            });
-
             // get post card price
             params.price_wei = recalc_price.get_price_wei();
             logger.log(prelog + 'price_wei: ' + params.price_wei);
-            buf_params.price_wei = Buffer.from(
-                config.web3.padLeft(params.price_wei.toString(16), 64),
-                'hex'
-            );
 
             logger.log(prelog + 'combining into text2sign hex string:');
             logger.log(prelog + 'wallet:        ' + wallet);
-            logger.log(prelog + 'hex name:      0x' + buf_params.name.toString('hex'));
-            logger.log(
-                prelog + 'hex country:   0x' + buf_params.country.toString('hex')
-            );
-            logger.log(prelog + 'hex state:     0x' + buf_params.state.toString('hex'));
-            logger.log(prelog + 'hex city:      0x' + buf_params.city.toString('hex'));
-            logger.log(
-                prelog + 'hex address:   0x' + buf_params.address.toString('hex')
-            );
-            logger.log(prelog + 'hex zip:       0x' + buf_params.zip.toString('hex'));
-            logger.log(
-                prelog + 'hex price_wei: 0x' + buf_params.price_wei.toString('hex')
-            );
             logger.log(prelog + 'sha3(cc):      ' + sha3cc);
-            var text2sign =
-                wallet +
-                Buffer.concat([
-                    buf_params.name,
-                    buf_params.country,
-                    buf_params.state,
-                    buf_params.city,
-                    buf_params.address,
-                    buf_params.zip,
-                    buf_params.price_wei,
-                    Buffer.from(sha3cc.substr(2), 'hex'),
-                ]).toString('hex');
-            logger.log(prelog + 'calling sign() with text2sign: ' + text2sign);
 
             try {
-                var sign_output = sign(text2sign);
+                var signatureParams = Object.assign(params, { wallet, sha3cc });
+
+                var sign_output = buildSignature(signatureParams);
                 logger.log(prelog + 'sign() output: ' + JSON.stringify(sign_output));
             } catch (e) {
                 logger.error(prelog + 'exception in sign(): ' + e.stack);

--- a/web-dapp/routes/prepare_reg_tx.js
+++ b/web-dapp/routes/prepare_reg_tx.js
@@ -119,7 +119,7 @@ module.exports = (opts) => {
             try {
                 var signatureParams = Object.assign(params, { wallet, sha3cc });
 
-                var sign_output = buildSignature(signatureParams);
+                var sign_output = buildSignature(signatureParams, config.signer_private_key);
                 logger.log(prelog + 'sign() output: ' + JSON.stringify(sign_output));
             } catch (e) {
                 logger.error(prelog + 'exception in sign(): ' + e.stack);

--- a/web-dapp/server-lib/buildSignature.js
+++ b/web-dapp/server-lib/buildSignature.js
@@ -1,0 +1,23 @@
+const sign = require('./sign');
+const Web3 = require('web3');
+
+function buildSignature(params, privateKey) {
+    var priceWei = Web3.prototype.padLeft(Web3.prototype.toBigNumber(params.price_wei).toString(16), 64);
+
+    var text2sign =
+        params.wallet +
+        Buffer.concat([
+            Buffer.from(params.name, 'utf8'),
+            Buffer.from(params.country, 'utf8'),
+            Buffer.from(params.state, 'utf8'),
+            Buffer.from(params.city, 'utf8'),
+            Buffer.from(params.address, 'utf8'),
+            Buffer.from(params.zip, 'utf8'),
+            Buffer.from(priceWei, 'hex'),
+            Buffer.from(params.sha3cc.substr(2), 'hex'),
+        ]).toString('hex');
+
+    return sign(text2sign, privateKey);
+}
+
+module.exports = buildSignature;

--- a/web-dapp/server-lib/sign.js
+++ b/web-dapp/server-lib/sign.js
@@ -48,7 +48,7 @@ function sign3(text) {
 
 var secp256k1 = require('secp256k1');
 
-function sign(text, privateKey = config.signer_private_key) {
+function sign(text, privateKey) {
     logger.log(prelog + 'signer: ' + config.signer);
     logger.log(prelog + 'text (must be in hex): ' + text);
     var sha = config.web3.sha3(text, { encoding: 'hex' });

--- a/web-dapp/server-lib/sign.js
+++ b/web-dapp/server-lib/sign.js
@@ -49,7 +49,6 @@ function sign3(text) {
 var secp256k1 = require('secp256k1');
 
 function sign(text, privateKey) {
-    logger.log(prelog + 'signer: ' + config.signer);
     logger.log(prelog + 'text (must be in hex): ' + text);
     var sha = config.web3.sha3(text, { encoding: 'hex' });
     logger.log(prelog + 'sha3(text): ' + sha); // hex string of sha3(text) => message

--- a/web-dapp/server-lib/sign.js
+++ b/web-dapp/server-lib/sign.js
@@ -48,7 +48,7 @@ function sign3(text) {
 
 var secp256k1 = require('secp256k1');
 
-function sign(text) {
+function sign(text, privateKey = config.signer_private_key) {
     logger.log(prelog + 'signer: ' + config.signer);
     logger.log(prelog + 'text (must be in hex): ' + text);
     var sha = config.web3.sha3(text, { encoding: 'hex' });
@@ -60,7 +60,7 @@ function sign(text) {
     var buff_message= Buffer.from(sha.substr(2), 'hex');
     var buff = Buffer.concat([buff_prefix, buff_length, buff_message]);
     var buff_sha3 = config.web3.sha3('0x' + buff.toString('hex'), { encoding: 'hex' });
-    var sig_obj = secp256k1.sign(Buffer.from(buff_sha3.substr(2), 'hex'), Buffer.from(config.signer_private_key, 'hex'));
+    var sig_obj = secp256k1.sign(Buffer.from(buff_sha3.substr(2), 'hex'), Buffer.from(privateKey, 'hex'));
     var sig = '0x' + sig_obj.signature.toString('hex') + (sig_obj.recovery? '01' : '00');
     logger.log(prelog + 'signature: ' + sig);
     sig = sig.substr(2, sig.length);


### PR DESCRIPTION
The smart contract tests need to build valid values for the secp256k1 signature. To make this easier and DRY, I moved the logic of building the text to sign to a reusable function, and used that in the tests.

This PR also:
- Fixes a problem with `db.set` (it was used with a callback, but it was promisified in a previous PR).
- Ignores files that start with `.` (hidden files in linux) when loading the route files.