### PR TITLE
(Feature) Check that contract is deployed by requesting owner

### DIFF
--- a/web-dapp/src/components/App.js
+++ b/web-dapp/src/components/App.js
@@ -6,6 +6,8 @@ import Footer from './Footer';
 import RegisterAddressPage from './RegisterAddressPage';
 import ConfirmationPage from './ConfirmationPage';
 
+import ContractOutput from '../contract-output';
+
 import '../assets/javascripts/init-my-web3.js';
 import '../assets/javascripts/show-alert.js';
 
@@ -21,6 +23,40 @@ class App extends Component {
             contract: null,
         };
         this.check_web3 = this.check_web3.bind(this);
+        this.check_contract = this.check_contract.bind(this);
+    }
+
+    check_contract(cconf, callback) {
+        console.log('checking contract');
+        var contract = window.my_web3.eth.contract(cconf.abi).at(cconf.address);
+        window.megaContract = contract;
+
+        window.my_web3.eth.getCode(cconf.address, function (err, code) {
+            if (err) {
+                console.log('error fetching code from address: ' + cconf.address + ', err: ' + err);
+                return callback();
+            }
+
+            // code here starts with 0x prefix in contrast with cconf.bytecode
+            if (code.length <= 2) {
+                console.log('code at address: ' + cconf.address + ' is empty: ' + code);
+                return callback();
+            }
+
+            contract.owner(function (err, owner) {
+                if (err) {
+                    console.log('error fetching owner: ' + err);
+                    return callback();
+                }
+
+                if (!owner || owner.length <= 2) {
+                    console.log('owner is empty: ' + owner);
+                    return callback();
+                }
+
+                return callback( contract );
+            });
+        });
     }
 
     check_web3() {
@@ -28,14 +64,26 @@ class App extends Component {
         if (window.my_web3) {
             console.log('web3 found, getting contract');
             clearInterval(this.state.web3_checker);
-            var cconf = require('../contract-output').ProofOfPhysicalAddress;
-            var contract = window.my_web3.eth.contract(cconf.abi).at(cconf.address);
-            window.megaContract = contract;
-            this.setState({
-                contract: contract,
-                my_web3: window.my_web3,
-                web3_checker: null,
-                web3_checker_dur: 0,
+            var cconf = ContractOutput.ProofOfPhysicalAddress;
+            this.check_contract(cconf, (contract) => {
+                if (contract) {
+                    console.log('contract is ok, saving to state');
+                    this.setState({
+                        contract: contract,
+                        my_web3: window.my_web3,
+                        web3_checker: null,
+                        web3_checker_dur: 0,
+                    });
+                }
+                else {
+                    console.log('contract is not ok');
+                    this.setState({
+                        contract: null,
+                        my_web3: window.my_web3,
+                        web3_checker: null,
+                        web3_checker_dur: 0,
+                    });
+                }
             });
         }
         else {
@@ -62,6 +110,20 @@ class App extends Component {
                     <Route exact path="/" component={() => <RegisterAddressPage my_web3={this.state.my_web3} contract={this.state.contract}/> } />
                     <Route path="/confirm" component={() => <ConfirmationPage my_web3={this.state.my_web3} contract={this.state.contract}/> } />
                     <Footer/>
+                </div>
+                </BrowserRouter>
+            );
+        }
+        else if (this.state.my_web3 && !this.state.contract) {
+            window.show_alert('error', 'Contract not deployed', 'PoPA contract is not deployed on this network');
+            return (
+                <BrowserRouter>
+                <div>
+                <Header/>
+                    <h2>Contract is not deployed</h2>
+                    PoPA contract is not deployed on this network, please switch network in metamask<br/>
+                    <br/>
+                <Footer/>
                 </div>
                 </BrowserRouter>
             );

--- a/web-dapp/src/components/App.js
+++ b/web-dapp/src/components/App.js
@@ -6,8 +6,6 @@ import Footer from './Footer';
 import RegisterAddressPage from './RegisterAddressPage';
 import ConfirmationPage from './ConfirmationPage';
 
-import ContractOutput from '../contract-output';
-
 import '../assets/javascripts/init-my-web3.js';
 import '../assets/javascripts/show-alert.js';
 
@@ -64,7 +62,7 @@ class App extends Component {
         if (window.my_web3) {
             console.log('web3 found, getting contract');
             clearInterval(this.state.web3_checker);
-            var cconf = ContractOutput.ProofOfPhysicalAddress;
+            var cconf = require('../contract-output').ProofOfPhysicalAddress;
             this.check_contract(cconf, (contract) => {
                 if (contract) {
                     console.log('contract is ok, saving to state');


### PR DESCRIPTION
- **What is it?** (leave one option)
    * New `(Feature)` implementation

- **What was the root cause of the problem originally / what feature was missing?**
If accidentally connected to wrong network, no warning is currently displayed, you can start using the DApp and receive various errors later.

- **How does this pull request solve it (in broad terms)?**
Check `code` property of account at `ContractOutput.address` (should be not empty).
Get `owner` of that contract (should be not empty).

- **Does it close any open issues?**
Related to https://github.com/poanetwork/poa-popa/issues/52

- **Quick checklist**
    - [ ] eslint shows no errors
        ```
        cd web-dapp
        eslint .
        ```
    - [X] docs were updated where necessary OR they don't need to be updated
    - [X] tests were updated where necessary OR they don't need to be updated


