### PR TITLE
(Fix) condition in confirmation code generation

### DIFF
--- a/web-dapp/server-lib/generate_code.js
+++ b/web-dapp/server-lib/generate_code.js
@@ -15,6 +15,10 @@ function generate_code() {
                 continue;
             }
             code += config.code_symbols[b%config.code_symbols.length];
+
+            if (code.length >= config.code_length) {
+                break;
+            }
         }
     } while (code.length < config.code_length);
 

--- a/web-dapp/test/server/generate_code.spec.js
+++ b/web-dapp/test/server/generate_code.spec.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const generate_code = require('../../server-lib/generate_code');
+const config = require('../../server-config');
+
+const TRIES = 1e4;
+
+describe('Confirmation code', () => {
+    it('cc length should be equal to the one in config', () => {
+        var pass = true;
+
+        for (let i = 0; i < TRIES; i++) {
+            let code = generate_code();
+            if (code.length !== config.code_length) {
+                pass = false;
+                break;
+            }
+        }
+
+        return expect(pass).toEqual(true);
+    });
+});


### PR DESCRIPTION
- **What is it?** (leave one option)
    * Bug `(Fix)`

- **What was the root cause of the problem originally / what feature was missing?**
Missing check for `code.length` in `for` loop, as a result sometimes code's length was greater than the one set in `config.code_length`

- **How does this pull request solve it (in broad terms)?**
Add check in `for` loop.
Also add test for this

- **Does it close any open issues?**
Closes #64 


- **Quick checklist**
    - [X] eslint shows no errors
        ```
        cd web-dapp
        eslint .
        ```
    - [X] docs were updated where necessary OR they don't need to be updated
    - [X] tests were updated where necessary OR they don't need to be updated

