### PR TITLE
(Improvement/refactor) Using the keccak256 to compare if an address matches a new entry.

### DIFF
--- a/blockchain/contracts/ProofOfPhysicalAddress.sol
+++ b/blockchain/contracts/ProofOfPhysicalAddress.sol
@@ -146,8 +146,9 @@ contract ProofOfPhysicalAddress
     public constant returns(bool, uint256, bool)
     {
         require(user_exists(wallet));
+        bytes32 keccak_identifier = keccak256(country, state, city, location, zip);
         for (uint256 ai = 0; ai < users[wallet].physical_addresses.length; ai += 1) {
-            if (users[wallet].physical_addresses[ai].keccak_identifier == keccak256(country, state, city, location, zip)) {
+            if (users[wallet].physical_addresses[ai].keccak_identifier == keccak_identifier) {
                 return (true, ai, user_address_confirmed(wallet, ai));
             }
         }

--- a/blockchain/contracts/ProofOfPhysicalAddress.sol
+++ b/blockchain/contracts/ProofOfPhysicalAddress.sol
@@ -8,9 +8,7 @@ contract ProofOfPhysicalAddress
     address public signer;
 
     // Main structures:
-
-    struct PhysicalAddress
-    {
+    struct PhysicalAddress {
         string name;
 
         string country;
@@ -20,6 +18,7 @@ contract ProofOfPhysicalAddress
         string zip;
 
         uint256 creation_block;
+        bytes32 keccak_identifier;
         bytes32 confirmation_code_sha3;
         uint256 confirmation_block;
     }
@@ -147,15 +146,8 @@ contract ProofOfPhysicalAddress
     public constant returns(bool, uint256, bool)
     {
         require(user_exists(wallet));
-        for (uint256 ai = 0; ai < users[wallet].physical_addresses.length; ai += 1)
-        {
-            if (
-                   str_eq(users[wallet].physical_addresses[ai].country, country)
-                && str_eq(users[wallet].physical_addresses[ai].state, state)
-                && str_eq(users[wallet].physical_addresses[ai].city, city)
-                && str_eq(users[wallet].physical_addresses[ai].location, location)
-                && str_eq(users[wallet].physical_addresses[ai].zip, zip))
-            {
+        for (uint256 ai = 0; ai < users[wallet].physical_addresses.length; ai += 1) {
+            if (users[wallet].physical_addresses[ai].keccak_identifier == keccak256(country, state, city, location, zip)) {
                 return (true, ai, user_address_confirmed(wallet, ai));
             }
         }
@@ -233,47 +225,34 @@ contract ProofOfPhysicalAddress
         );
         require(signer_is_valid(data, sig_v, sig_r, sig_s));
 
-        PhysicalAddress memory pa;
-        if (user_exists(msg.sender))
-        {
+        if (user_exists(msg.sender)) {
             // check if this address is already registered
             bool found;
             (found, , ) = user_address_by_address(msg.sender, country, state, city, location, zip);
 
-            if (found) revert();
-
-            // not registered yet:
-            pa.name = name;
-            pa.country = country;
-            pa.state = state;
-            pa.city = city;
-            pa.location = location;
-            pa.zip = zip;
-            pa.creation_block = block.number;
-            pa.confirmation_code_sha3 = confirmation_code_sha3;
-            pa.confirmation_block = 0;
-            users[msg.sender].physical_addresses.push(pa);
-
-            total_addresses += 1;
-        }
-        else
-        {
+            require(!found);
+        } else {
             // new user
             users[msg.sender].creation_block = block.number;
-            pa.name = name;
-            pa.country = country;
-            pa.state = state;
-            pa.city = city;
-            pa.location = location;
-            pa.zip = zip;
-            pa.creation_block = block.number;
-            pa.confirmation_code_sha3 = confirmation_code_sha3;
-            pa.confirmation_block = 0;
-            users[msg.sender].physical_addresses.push(pa);
 
             total_users += 1;
-            total_addresses += 1;
         }
+
+        PhysicalAddress memory pa;
+
+        pa.name = name;
+        pa.country = country;
+        pa.state = state;
+        pa.city = city;
+        pa.location = location;
+        pa.zip = zip;
+        pa.creation_block = block.number;
+        pa.confirmation_code_sha3 = confirmation_code_sha3;
+        pa.keccak_identifier = keccak256(country, state, city, location, zip);
+        pa.confirmation_block = 0;
+        users[msg.sender].physical_addresses.push(pa);
+
+        total_addresses += 1;
     }
 
     function confirm_address(string confirmation_code_plain, uint8 sig_v, bytes32 sig_r, bytes32 sig_s)


### PR DESCRIPTION
Before submitting a pull request, please provide the following information:

- **What is it?** (leave one option)
    * `(Improvement)` of existing functionality
    * `(Refactor)` of existing code (no functionality change)

- **What was the root cause of the problem originally / what feature was missing?**
Instead of having a byte per byte comparison, addresses are hashed using `keccak256` and that hash is being compared.

- **How does this pull request solve it (in broad terms)?**
I stored the `keccac256` hash in the `PhysicalAddress` struct in the registration and the lookup just checks if the keccak matches.

- **Does it close any open issues?**
Closes #77 


- **Quick checklist**
    - [x] docs were updated where necessary OR they don't need to be updated
    - [x] tests were updated where necessary OR they don't need to be updated

- **Additional information**

I performed a small refactor in the `register_address` function. Just cleaning up some duplicated code.