### PR TITLE
(Fix) sending address registration txs multiple times

### DIFF
--- a/web-dapp/controllers/notifyRegTx.js
+++ b/web-dapp/controllers/notifyRegTx.js
@@ -30,7 +30,7 @@ const validateData = (opts, prelog = '') => {
         return createResponseObject(false, validate.string(body.txId).msg);
     }
     // sessionKey
-    if (!validate.string(body.sessionKey).ok) {
+    if (!validate.string(body.sessionKey).ok || isNaN(Number(body.sessionKey))) {
         logger.log(`${prelog} validation error on sessionKey: body.sessionKey, error: ${validate.string(body.sessionKey).msg}`);
         return createResponseObject(false, validate.string(body.sessionKey).msg);
     }

--- a/web-dapp/server-lib/session-stores/memory.js
+++ b/web-dapp/server-lib/session-stores/memory.js
@@ -1,6 +1,10 @@
 'use strict';
 
 let db = {};
+function k1(k) {
+    return `locked:${k}`;
+}
+
 module.exports = function () {
     return {
         set: function (k,v) {
@@ -10,13 +14,15 @@ module.exports = function () {
             });
         },
         get: (k) => {
+            db[k1(k)] = db[k];
+            delete db[k];
             return new Promise((resolve) => {
-                return resolve(db[k]);
+                return resolve(db[k1(k)]);
             });
         },
         unset: (k) => {
+            delete db[k1(k)];
             return new Promise((resolve) => {
-                delete db[k];
                 return resolve(true);
             });
         },

--- a/web-dapp/server-lib/session-stores/redis.js
+++ b/web-dapp/server-lib/session-stores/redis.js
@@ -40,7 +40,7 @@ module.exports = function () {
         },
         get: (k) => {
             return new Promise((resolve, reject) => {
-                client.rename(k, k1(k), (err, v) => {
+                client.rename(k, k1(k), (err) => {
                     if (err) return reject(err);
                     client.get(k1(k), (err, v) => {
                         if (err) return reject(err);
@@ -52,7 +52,7 @@ module.exports = function () {
                             return reject(ex);
                         }
                     });
-                })
+                });
             });
         },
         unset: (k) => {

--- a/web-dapp/server-lib/session-stores/redis.js
+++ b/web-dapp/server-lib/session-stores/redis.js
@@ -5,6 +5,10 @@ const redis = require('redis'); // https://github.com/NodeRedis/node_redis
 
 const prelog = '[redis]';
 
+function k1(k) {
+    return `locked:${k}`;
+}
+
 module.exports = function () {
     logger.log(`${prelog} connecting`);
 
@@ -36,21 +40,24 @@ module.exports = function () {
         },
         get: (k) => {
             return new Promise((resolve, reject) => {
-                client.get(k, (err, v) => {
+                client.rename(k, k1(k), (err, v) => {
                     if (err) return reject(err);
-                    try {
-                        v = JSON.parse(v);
-                        return resolve(v);
-                    }
-                    catch (ex) {
-                        return reject(ex);
-                    }
-                });
+                    client.get(k1(k), (err, v) => {
+                        if (err) return reject(err);
+                        try {
+                            v = JSON.parse(v);
+                            return resolve(v);
+                        }
+                        catch (ex) {
+                            return reject(ex);
+                        }
+                    });
+                })
             });
         },
         unset: (k) => {
             return new Promise((resolve) => {
-                client.del(k);
+                client.del(k1(k));
                 return resolve(true);
             });
         },


### PR DESCRIPTION
- **What is it?** (leave one option)
    * Bug `(Fix)`

- **What was the root cause of the problem originally / what feature was missing?**
When sending request to notifyRegTx with tx_id, it was possible to use the same request multiple times (until first postcard was created) to make server send multiple postcards to the same address 

- **How does this pull request solve it (in broad terms)?**
Session-stores rename the key when `get` method is called:
```
key -> locked:key
```
so that if `get` is called again with the same `key`, it is does not exist anymore.
Also, renaming is used in `unset` method to delete successfully used key from memory.
Also, a validation is added to check that session_key is a number, otherwise one could pass `locked:key` second time, then `locked:locked:key`, etc...

- **Does it close any open issues?**
Closes #105 

