### PR TITLE
(Feature) Show spinner when confirming and removing addresses

### DIFF
--- a/web-dapp/src/components/ConfirmationPage.test.js
+++ b/web-dapp/src/components/ConfirmationPage.test.js
@@ -2,8 +2,14 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import ConfirmationPage from './ConfirmationPage';
+import * as waitForTransaction from '../waitForTransaction';
 
-const web3 = { eth: { accounts: ['0x1aa2d288d03d8397c193d2327ee7a7443d4ec3a1'] } };
+const web3 = {
+  eth: {
+    accounts: ['0x1aa2d288d03d8397c193d2327ee7a7443d4ec3a1'],
+    getTransactionReceipt: jest.fn()
+  }
+};
 const contract = require('../ProofOfPhysicalAddress.json');
 
 window.$ = { ajax: jest.fn() };
@@ -348,7 +354,7 @@ describe('<ConfirmationPage />', () => {
         );
     });
 
-    it('displays a message if there was an error confirming address', () => {
+    it('displays a message if there was an error confirming address', (done) => {
         const page = mount(
             <ConfirmationPage
                 my_web3={web3}
@@ -368,24 +374,27 @@ describe('<ConfirmationPage />', () => {
             return callback(null, { found: true, ...addressDetails });
         });
 
-        confirmAddress.mockImplementationOnce((opts, callback) => {
-            return callback({ message: 'fake confirmation error' });
+        confirmAddress.mockImplementationOnce((opts) => {
+            return Promise.reject({ message: 'fake confirmation error' });
         });
 
         page.find('.postcard-button').simulate('click');
 
-        expect(checkUserExists).toHaveBeenCalled();
-        expect(checkWalletSame).toHaveBeenCalled();
-        expect(ajaxCall).toHaveBeenCalled();
-        expect(findAddress).toHaveBeenCalled();
-        expect(showAlert).toHaveBeenLastCalledWith(
-            'error',
-            'Confirming address',
-            [['Error', 'fake confirmation error']]
-        );
+        setTimeout(() => {
+            expect(checkUserExists).toHaveBeenCalled();
+            expect(checkWalletSame).toHaveBeenCalled();
+            expect(ajaxCall).toHaveBeenCalled();
+            expect(findAddress).toHaveBeenCalled();
+            expect(showAlert).toHaveBeenLastCalledWith(
+                'error',
+                'Confirming address',
+                [['Error', 'fake confirmation error']]
+                );
+            done();
+        })
     });
 
-    it('displays a message when received an unexpected JSON RPC response', () => {
+    it('displays a message when received an unexpected JSON RPC response', (done) => {
         const page = mount(
             <ConfirmationPage
                 my_web3={web3}
@@ -404,23 +413,26 @@ describe('<ConfirmationPage />', () => {
         });
 
         confirmAddress.mockImplementationOnce((opts, callback) => {
-            return callback();
+            return Promise.resolve();
         });
 
         page.find('.postcard-button').simulate('click');
 
-        expect(checkUserExists).toHaveBeenCalled();
-        expect(checkWalletSame).toHaveBeenCalled();
-        expect(ajaxCall).toHaveBeenCalled();
-        expect(findAddress).toHaveBeenCalled();
-        expect(showAlert).toHaveBeenLastCalledWith(
-            'error',
-            'Confirming address',
-            'Error is empty but txId is also empty'
-        );
+        setTimeout(() => {
+            expect(checkUserExists).toHaveBeenCalled();
+            expect(checkWalletSame).toHaveBeenCalled();
+            expect(ajaxCall).toHaveBeenCalled();
+            expect(findAddress).toHaveBeenCalled();
+            expect(showAlert).toHaveBeenLastCalledWith(
+                'error',
+                'Confirming address',
+                'Error is empty but txId is also empty'
+                );
+            done();
+        })
     });
 
-    it('displays a message if there was an error estimating gas for transaction', () => {
+    it('displays a message if there was an error estimating gas for transaction', (done) => {
         const page = mount(
             <ConfirmationPage
                 my_web3={web3}
@@ -456,16 +468,19 @@ describe('<ConfirmationPage />', () => {
 
         page.find('.postcard-button').simulate('click');
 
-        expect(checkUserExists).toHaveBeenCalled();
-        expect(checkWalletSame).toHaveBeenCalled();
-        expect(ajaxCall).toHaveBeenCalled();
-        expect(findAddress).toHaveBeenCalled();
-        expect(showAlert).toHaveBeenLastCalledWith(
-            'error',
-            'Confirming address',
-            [['Error', 'fake error']]
-        );
-    });
+        setTimeout(() => {
+            expect(checkUserExists).toHaveBeenCalled();
+            expect(checkWalletSame).toHaveBeenCalled();
+            expect(ajaxCall).toHaveBeenCalled();
+            expect(findAddress).toHaveBeenCalled();
+            expect(showAlert).toHaveBeenLastCalledWith(
+                'error',
+                'Confirming address',
+                [['Error', 'fake error']]
+            );
+            done();
+        })
+    })
 
     it('displays a message when a address was confirmed successfully', () => {
         const contract = {
@@ -504,26 +519,29 @@ describe('<ConfirmationPage />', () => {
 
         page.find('.postcard-button').simulate('click');
 
-        expect(checkUserExists).toHaveBeenCalled();
-        expect(checkWalletSame).toHaveBeenCalled();
-        expect(ajaxCall).toHaveBeenCalled();
-        expect(findAddress).toHaveBeenCalled();
-        expect(showAlert).toHaveBeenLastCalledWith(
-            'success',
-            'Address confirmed!',
-            [
-                ['Transaction to confirm address was submitted'],
-                ['Transaction ID', '0xfd3c97d14b3979cc6356a92b79b3ac8038f0065fc5079c6a0a0ff9b0c0786291'],
-                ['Country', 'US'],
-                ['State', 'NM'],
-                ['City', 'ALBUQUERQUE'],
-                ['Address', '3828 PIERMONT DR NE'],
-                ['ZIP code', '87111']
-            ]
-        );
+        setTimeout(() => {
+            expect(checkUserExists).toHaveBeenCalled();
+            expect(checkWalletSame).toHaveBeenCalled();
+            expect(ajaxCall).toHaveBeenCalled();
+            expect(findAddress).toHaveBeenCalled();
+            expect(showAlert).toHaveBeenLastCalledWith(
+                'success',
+                'Address confirmed!',
+                [
+                    ['Transaction to confirm address was submitted'],
+                    ['Transaction ID', '0xfd3c97d14b3979cc6356a92b79b3ac8038f0065fc5079c6a0a0ff9b0c0786291'],
+                    ['Country', 'US'],
+                    ['State', 'NM'],
+                    ['City', 'ALBUQUERQUE'],
+                    ['Address', '3828 PIERMONT DR NE'],
+                    ['ZIP code', '87111']
+                ]
+            );
+            done();
+        })
     });
 
-    it('displays a message when a address was confirmed successfully', () => {
+    it('displays a message when a address was confirmed successfully', (done) => {
         const page = mount(
             <ConfirmationPage
                 my_web3={web3}
@@ -541,28 +559,33 @@ describe('<ConfirmationPage />', () => {
             return callback(null, { found: true, ...addressDetails });
         });
 
-        confirmAddress.mockImplementationOnce((opts, callback) => {
-            return callback(null, '0xfd3c97d14b3979cc6356a92b79b3ac8038f0065fc5079c6a0a0ff9b0c0786291');
+        confirmAddress.mockImplementationOnce((opts) => {
+            return Promise.resolve('0xfd3c97d14b3979cc6356a92b79b3ac8038f0065fc5079c6a0a0ff9b0c0786291');
         });
+
+        waitForTransaction.default = jest.fn().mockImplementationOnce(() => Promise.resolve())
 
         page.find('.postcard-button').simulate('click');
 
-        expect(checkUserExists).toHaveBeenCalled();
-        expect(checkWalletSame).toHaveBeenCalled();
-        expect(ajaxCall).toHaveBeenCalled();
-        expect(findAddress).toHaveBeenCalled();
-        expect(showAlert).toHaveBeenLastCalledWith(
-            'success',
-            'Address confirmed!',
-            [
-                ['Transaction to confirm address was submitted'],
-                ['Transaction ID', '0xfd3c97d14b3979cc6356a92b79b3ac8038f0065fc5079c6a0a0ff9b0c0786291'],
-                ['Country', 'US'],
-                ['State', 'NM'],
-                ['City', 'ALBUQUERQUE'],
-                ['Address', '3828 PIERMONT DR NE'],
-                ['ZIP code', '87111']
-            ]
-        );
+        setTimeout(() => {
+            expect(checkUserExists).toHaveBeenCalled();
+            expect(checkWalletSame).toHaveBeenCalled();
+            expect(ajaxCall).toHaveBeenCalled();
+            expect(findAddress).toHaveBeenCalled();
+            expect(showAlert).toHaveBeenLastCalledWith(
+                'success',
+                'Address confirmed!',
+                [
+                    ['Transaction to confirm address was submitted'],
+                    ['Transaction ID', '0xfd3c97d14b3979cc6356a92b79b3ac8038f0065fc5079c6a0a0ff9b0c0786291'],
+                    ['Country', 'US'],
+                    ['State', 'NM'],
+                    ['City', 'ALBUQUERQUE'],
+                    ['Address', '3828 PIERMONT DR NE'],
+                    ['ZIP code', '87111']
+                ]
+            );
+            done();
+        })
     });
 });

--- a/web-dapp/src/components/MyAddressesPage.js
+++ b/web-dapp/src/components/MyAddressesPage.js
@@ -2,6 +2,7 @@ import React from 'react';
 import * as log from 'loglevel';
 
 import {Loading} from './Loading';
+import waitForTransaction from '../waitForTransaction';
 
 import '../assets/javascripts/show-alert.js';
 
@@ -107,15 +108,23 @@ class ConfirmationPage extends React.Component {
 
         const contract = this.props.contract;
 
+        this.setState({ loading: true })
         contract.unregisterAddress(country, state, city, location, zip, {
             gas: '1000000'
-        }, (err, result) => {
+        }, (err, txId) => {
             if (err) {
                 logger.debug('Error calling contract.unregisterAddress:', err);
                 return;
             }
 
-            window.location.reload();
+            waitForTransaction(this.props.my_web3, txId)
+                .then(() => {
+                    window.location.reload();
+                })
+                .catch((e) => {
+                    logger.error('Error waiting for transaction: ', e);
+                    this.setState({ loading: false });
+                });
         });
     }
 

--- a/web-dapp/src/components/MyAddressesPage.test.js
+++ b/web-dapp/src/components/MyAddressesPage.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { mount } from 'enzyme';
 
 import MyAddressesPage from './MyAddressesPage';
+import * as waitForTransaction from '../waitForTransaction';
 
 const web3 = { eth: { accounts: ['0x1aa2d288d03d8397c193d2327ee7a7443d4ec3a1'] } };
 
@@ -24,18 +25,23 @@ describe('<MyAddressesPage />', () => {
         expect(page.state('addresses').length).toBe(2)
     })
 
-    it('should reload page after removing an address', () => {
+    it('should reload page after removing an address', (done) => {
         const reloadSpy = jest.spyOn(window.location, 'reload').mockImplementation(() => {})
         const contractMock = buildContractMock({ count: 2 })
         const page = mount(<MyAddressesPage my_web3={web3} contract={contractMock}/>);
 
+        waitForTransaction.default = jest.fn().mockImplementationOnce(() => Promise.resolve())
+
         const e = { preventDefault: jest.fn() }
         page.instance().remove(e, 'country', 'state', 'city', 'location', 'zip')
 
-        expect(reloadSpy).toHaveBeenCalled()
+        setTimeout(() => {
+            expect(reloadSpy).toHaveBeenCalled()
 
-        reloadSpy.mockReset()
-        reloadSpy.mockRestore()
+            reloadSpy.mockReset()
+            reloadSpy.mockRestore()
+            done();
+        })
     })
 });
 

--- a/web-dapp/src/waitForTransaction.js
+++ b/web-dapp/src/waitForTransaction.js
@@ -1,0 +1,20 @@
+export default function waitForTransaction(web3, txId) {
+    let transactionReceiptAsync;
+    transactionReceiptAsync = function(txId, resolve, reject) {
+        web3.eth.getTransactionReceipt(txId, (err, receipt) => {
+            if (err) {
+                reject(err)
+            } else if (receipt == null) {
+                setTimeout(function () {
+                    transactionReceiptAsync(txId, resolve, reject);
+                }, 500);
+            } else {
+                resolve(receipt);
+            }
+        });
+    };
+
+    return new Promise(function (resolve, reject) {
+        transactionReceiptAsync(txId, resolve, reject);
+    });
+}


### PR DESCRIPTION
After confirming or removing an address, wait for the transaction to be mined before hiding the spinner.

This is not a big change, but it seems to add some level of async that made a lot of test fail. I added a bunch of `setTimeout`s to make them pass (so that the expects are called after every async funtion was called), but I'm not a fan of this solution. Please let me know if you know a better way to do this.