### PR TITLE
(Chore) Apply linter in all files

### DIFF
--- a/web-dapp/.eslintignore
+++ b/web-dapp/.eslintignore
@@ -2,6 +2,7 @@ build
 node_modules
 postcard
 public
+coverage
 src/assets
 src/components
 server-config-private.js

--- a/web-dapp/.eslintrc.yml
+++ b/web-dapp/.eslintrc.yml
@@ -15,6 +15,7 @@ plugins:
   - jsx-a11y
   - json
 globals:
+  jasmine: false
   jest: false
   describe: false
   xdescribe: false

--- a/web-dapp/controllers/notifyRegTx.js
+++ b/web-dapp/controllers/notifyRegTx.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const config = require('../server-config');
 const db = require('../server-lib/session_store');
 const postApi = require('../server-lib/post_api');
 const logger = require('../server-lib/logger');
@@ -66,7 +65,7 @@ const getTxBlockNumber = (opts, prelog = '') => {
             logger.log(`${prelog} got block number for txId: ${txId}, txBn: ${txDetails.blockNumber}`);
             return txDetails.blockNumber;
         })
-        .then((blockNumber) => {
+        .then(() => {
             logger.log(`${prelog} checking tx receipt for status`);
             return getTxReceipt(txId);
         })

--- a/web-dapp/controllers/prepareRegTx.js
+++ b/web-dapp/controllers/prepareRegTx.js
@@ -33,11 +33,11 @@ const validateZip = (body) => {
 const validateParams = (body, param) => {
     return new Promise((resolve, reject) => {
         const result = (param === 'wallet') ? validate.wallet(body[param]) : validate.string(body[param]);
-       if (!result.ok) {
-           const log = `validation error on ${param}: ${body[param]}, err: ${result.msg}`;
-           return reject({...result, log});
-       }
-       return resolve(body)
+        if (!result.ok) {
+            const log = `validation error on ${param}: ${body[param]}, err: ${result.msg}`;
+            return reject({...result, log});
+        }
+        return resolve(body);
     });
 };
 
@@ -46,15 +46,15 @@ const validateData = (data = {}) => {
         if (!data || !Object.keys(data).length) return reject({ok: false, log: 'request body empty', msg: 'request body empty'});
         return resolve(data);
     })
-    .then(validateWallet)
-    .then(validateName)
-    .then(validateCountry)
-    .then(validateState)
-    .then(validateCity)
-    .then(validateAddress)
-    .then(validateZip)
-    .then(verifyAddress)
-    .then(normalizeData);
+        .then(validateWallet)
+        .then(validateName)
+        .then(validateCountry)
+        .then(validateState)
+        .then(validateCity)
+        .then(validateAddress)
+        .then(validateZip)
+        .then(verifyAddress)
+        .then(normalizeData);
 };
 
 const verifyAddress = (params) => {

--- a/web-dapp/package.json
+++ b/web-dapp/package.json
@@ -6,7 +6,7 @@
     "start": "react-scripts start",
     "build": "npm run build-css && react-scripts build",
     "build-css": "node-sass ./src/assets/stylesheets/application.scss ./src/assets/stylesheets/application.css",
-    "lint": "eslint routes/* server-lib/** src/**",
+    "lint": "eslint .",
     "test": "react-scripts test --testMatch **/test/server/**/*.spec.js **/src/**/*.test.js --env=jsdom --coverage"
   },
   "dependencies": {

--- a/web-dapp/test/server/_utils/mocks.js
+++ b/web-dapp/test/server/_utils/mocks.js
@@ -15,7 +15,7 @@ const confirmationCodes = [
 ];
 
 const confirmationCodesSha3 = [
-    '0x8c4d9d5a199f6619fe6ab0a3e319122048f0b10c10ace064d39657cbd37f123f'
+    '0x8c4d9d5a199f6619fe6ab0a3e319122048f0b10c10ace064d39657cbd37f123f',
 ];
 
 const sessionKeys = [
@@ -55,8 +55,8 @@ const mockDb = {
 const mockGetTransaction = (txId) => {
     const response = {
         error: null,
-        txDetails: null
-    }
+        txDetails: null,
+    };
     if (txId === txIds[5]) {
         response.error = 'Error getting transaction';
     }

--- a/web-dapp/test/server/log_request.spec.js
+++ b/web-dapp/test/server/log_request.spec.js
@@ -1,30 +1,32 @@
-import { stub } from 'sinon';
+'use strict';
+
+const stub = require('sinon').stub;
 
 const logger = require('../../server-lib/logger');
 const log_request = require('../../server-lib/log_request');
 
 describe('Log Request', () => {
-  afterAll(() => {
-    logger.log.restore();
-  });
+    afterAll(() => {
+        logger.log.restore();
+    });
 
-  it('should log the request', () => {
-    stub(logger, 'log');
+    it('should log the request', () => {
+        stub(logger, 'log');
 
-    const req = {
-      x_id: 'P4cGqk',
-      x_ip: '127.0.0.1',
-      method: 'POST',
-      path: '/prepareRegTx',
-      headers: {
-        'host': 'localhost:3000'
-      }
-    };
-    const res = {};
-    const next = () => {};
+        const req = {
+            x_id: 'P4cGqk',
+            x_ip: '127.0.0.1',
+            method: 'POST',
+            path: '/prepareRegTx',
+            headers: {
+                'host': 'localhost:3000',
+            },
+        };
+        const res = {};
+        const next = () => {};
 
-    log_request(req, res, next);
+        log_request(req, res, next);
 
-    expect(logger.log.calledOnce).toBeTruthy();
-  });
+        expect(logger.log.calledOnce).toBeTruthy();
+    });
 });

--- a/web-dapp/test/server/logger.spec.js
+++ b/web-dapp/test/server/logger.spec.js
@@ -1,33 +1,35 @@
-import { spy } from 'sinon';
+'use strict';
+
+const spy = require('sinon').spy;
 
 const logger = require('../../server-lib/logger');
 
 describe('Logger', () => {
-  describe('Logger.log', () => {
-    afterAll(() => {
-      logger.log.restore();
+    describe('Logger.log', () => {
+        afterAll(() => {
+            logger.log.restore();
+        });
+
+        it('should show logger.log', () => {
+            spy(logger, 'log');
+
+            logger.log('lorem ipsum');
+
+            expect(logger.log.calledOnce).toBeTruthy();
+        });
     });
 
-    it('should show logger.log', () => {
-      spy(logger, 'log');
+    describe('Logger.error', () => {
+        afterAll(() => {
+            logger.error.restore();
+        });
 
-      logger.log('lorem ipsum');
+        it('should show logger.error', () => {
+            spy(logger, 'error');
 
-      expect(logger.log.calledOnce).toBeTruthy();
+            logger.error('lorem ipsum');
+
+            expect(logger.error.calledOnce).toBeTruthy();
+        });
     });
-  });
-
-  describe('Logger.error', () => {
-    afterAll(() => {
-      logger.error.restore();
-    });
-
-    it('should show logger.error', () => {
-      spy(logger, 'error');
-
-      logger.error('lorem ipsum');
-
-      expect(logger.error.calledOnce).toBeTruthy();
-    });
-  });
 });

--- a/web-dapp/test/server/notifyRegTx.spec.js
+++ b/web-dapp/test/server/notifyRegTx.spec.js
@@ -5,23 +5,16 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 0;
 const {
     wallets,
     badWallets,
-    confirmationCodes,
     sessionKeys,
     badSessionKeys,
     txIds,
     badTxIds} = require(path.join(__dirname, './_utils/mocks'));
 const [walletA, walletB, walletC] = wallets;
 const [badWallet] = badWallets;
-const [confCodePlain] = confirmationCodes;
 const [sessionKey] = sessionKeys;
 const [badSessionKey] = badSessionKeys;
-const [txIdA, txIdB, txIdC, txIdD, txIdE, txIdF, txIdG] = txIds;
+const [txIdA, , , , , , txIdG] = txIds;
 const [badTxId] = badTxIds;
-
-const info = {
-    wallet: walletA,
-    confirmationCodePlain: confCodePlain,
-};
 
 const {
     mockDb,
@@ -31,7 +24,7 @@ const {
     mockGetAddressDetails } = require('./_utils/mocks');
 
 jest.mock('../../server-lib/session_store', () => ({
-    get: jest.fn(mockDb.get)
+    get: jest.fn(mockDb.get),
 }));
 jest.mock('../../server-lib/get_transaction', () => jest.fn(mockGetTransaction));
 jest.mock('../../server-lib/get_tx_receipt', () => jest.fn(mockGetTxReceipt));
@@ -86,7 +79,7 @@ describe('Notify Register Transactions', () => {
                     wallet: walletA,
                     txId: txIdA,
                     sessionKey,
-                }
+                },
             };
             const result = notifyRegTx.validateData(opts);
             expect(result.ok).toBeTruthy();
@@ -111,7 +104,7 @@ describe('Notify Register Transactions', () => {
     describe('Get Info', () => {
         it('should return info for the sessionKey', () => {
             const opts = {sessionKey, wallet: walletA};
-            return expect(notifyRegTx.getTxInfo(opts)).resolves.toBeTruthy()
+            return expect(notifyRegTx.getTxInfo(opts)).resolves.toBeTruthy();
         });
         it('should return an error there is not info for the sessionKey', () => {
             const opts = {sessionKey: badSessionKey, wallet: walletA};

--- a/web-dapp/test/server/prepareConTx.spec.js
+++ b/web-dapp/test/server/prepareConTx.spec.js
@@ -6,7 +6,7 @@ jest.mock('../../server-lib/sign', () => jest.fn(() => ({
     v: 28,
     r: '0xe96cb9bb53cb3652f587161ad5f4edd6aef683210660601444f37860f20f7bb9',
     s: '0x1d2aed920f79979468fb2c069c2fd5f6af54331d0df353bba0c1d847f525905c',
-})))
+})));
 const prepareConTx = require('../../controllers/prepareConTx');
 
 describe('Prepare Reg Transaction', () => {
@@ -17,7 +17,7 @@ describe('Prepare Reg Transaction', () => {
         it('should reject if wallet is not valid', () => {
             const data = {
                 wallet: badWallet,
-                confirmationCodePlain: 'sxxsndac7y7'
+                confirmationCodePlain: 'sxxsndac7y7',
             };
             return expect(prepareConTx.validateData(data)).rejects.toBeTruthy();
         });
@@ -31,7 +31,7 @@ describe('Prepare Reg Transaction', () => {
         it('should return wallet and params', () => {
             const data = {
                 wallet,
-                confirmationCodePlain: 'sxxsndac7y7'
+                confirmationCodePlain: 'sxxsndac7y7',
             };
 
             return prepareConTx.validateData(data)
@@ -46,7 +46,7 @@ describe('Prepare Reg Transaction', () => {
     describe('Hex params', () => {
         it('should return an object with hex values', () => {
             const params = {
-                confirmationCodePlain: 'sxxsndac7y7'
+                confirmationCodePlain: 'sxxsndac7y7',
             };
             const hexParams = prepareConTx.hexParams(params);
             const expected = Buffer.from(params.confirmationCodePlain, 'utf8');

--- a/web-dapp/test/server/prepare_con_tx.spec.js
+++ b/web-dapp/test/server/prepare_con_tx.spec.js
@@ -18,7 +18,7 @@ describe('prepare_con_tx', () => {
             .post('/api/prepareConTx')
             .send({
                 wallet: '0x1aa2d288d03d8397c193d2327ee7a7443d4ec3a1',
-                confirmationCodePlain: 'sxxsndac7y7'
+                confirmationCodePlain: 'sxxsndac7y7',
             })
             .then(res => {
                 return expect(res.body.ok).toBeTruthy();


### PR DESCRIPTION
The linter was only being applied to a subset of the javascript files. Most importantly, it wasn't being applied to the controllers files.

This PR makes the `lint` script to be applied to all files, and fixes all warnings/errors found.