### PR TITLE
Add tests for PoPA contract

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true
+
+[*.{js,sol}]
+indent_style = space
+indent_size = 4

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+build
+node_modules
+postcard
+public
+coverage
+web-dapp/src/assets
+web-dapp/src/components
+server-config-private.js

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,58 @@
+env:
+  es6: true
+  node: true
+extends:
+  - 'eslint:recommended'
+  - 'plugin:react/recommended'
+parserOptions:
+  sourceType: script
+  ecmaVersion: 8
+  ecmaFeatures:
+    jsx: true
+    modules: true
+    experimentalObjectRestSpread: true
+plugins:
+  - react
+  - jsx-a11y
+  - json
+globals:
+  jasmine: false
+  jest: false
+  describe: false
+  xdescribe: false
+  it: false
+  xit: false
+  after: false
+  afterAll: false
+  afterEach: false
+  before: false
+  beforeAll: false
+  beforeEach: false
+  expect: false
+  document: false
+  window: false
+  navigator: false
+  fetch: false
+  URL: false
+rules:
+  indent:
+    - warn
+    - 4
+  linebreak-style:
+    - error
+    - unix
+  quotes:
+    - warn
+    - single
+  comma-dangle:
+    - warn
+    - always-multiline
+  semi:
+    - error
+    - always
+  eqeqeq:
+    - error
+    - smart
+  strict:
+    - error
+    - never

--- a/blockchain/.eslintrc.yml
+++ b/blockchain/.eslintrc.yml
@@ -1,0 +1,5 @@
+globals:
+  artifacts: false
+  assert: false
+  contract: false
+  web3: false

--- a/blockchain/migrations/1522104575_popa.js
+++ b/blockchain/migrations/1522104575_popa.js
@@ -1,21 +1,21 @@
-var POPA = artifacts.require("ProofOfPhysicalAddress");
-var PhysicalAddressClaim = artifacts.require("PhysicalAddressClaim");
-var EthereumClaimsRegistry = artifacts.require("EthereumClaimsRegistry");
+var POPA = artifacts.require('ProofOfPhysicalAddress');
+var PhysicalAddressClaim = artifacts.require('PhysicalAddressClaim');
+var EthereumClaimsRegistry = artifacts.require('EthereumClaimsRegistry');
 
-module.exports = function(deployer, network, accounts) {
-  return deployer.then(async () => {
-    await deployer.deploy(PhysicalAddressClaim);
-    await deployer.link(PhysicalAddressClaim, POPA);
+module.exports = function(deployer, network) {
+    return deployer.then(async () => {
+        await deployer.deploy(PhysicalAddressClaim);
+        await deployer.link(PhysicalAddressClaim, POPA);
 
-    let ethereumClaimsRegistryAddress = null
-    if (network === 'development' || network === 'coverage') {
-      await deployer.deploy(EthereumClaimsRegistry);
-      let ethereumClaimsRegistry = await EthereumClaimsRegistry.deployed();
-      ethereumClaimsRegistryAddress = ethereumClaimsRegistry.address
-    } else {
-      ethereumClaimsRegistryAddress = '0xaca1bcd8d0f5a9bfc95aff331da4c250cd9ac2da'
-    }
+        let ethereumClaimsRegistryAddress = null;
+        if (network === 'development' || network === 'coverage') {
+            await deployer.deploy(EthereumClaimsRegistry);
+            let ethereumClaimsRegistry = await EthereumClaimsRegistry.deployed();
+            ethereumClaimsRegistryAddress = ethereumClaimsRegistry.address;
+        } else {
+            ethereumClaimsRegistryAddress = '0xaca1bcd8d0f5a9bfc95aff331da4c250cd9ac2da';
+        }
 
-    await deployer.deploy(POPA, ethereumClaimsRegistryAddress);
-  });
+        await deployer.deploy(POPA, ethereumClaimsRegistryAddress);
+    });
 };

--- a/blockchain/migrations/1_initial_migration.js
+++ b/blockchain/migrations/1_initial_migration.js
@@ -1,5 +1,5 @@
-var Migrations = artifacts.require("./Migrations.sol");
+const Migrations = artifacts.require('./Migrations.sol');
 
 module.exports = function(deployer) {
-  deployer.deploy(Migrations);
+    deployer.deploy(Migrations);
 };

--- a/blockchain/test/ethereum_claims_registry_specs.js
+++ b/blockchain/test/ethereum_claims_registry_specs.js
@@ -1,79 +1,79 @@
-const EthereumClaimsRegistry = artifacts.require("EthereumClaimsRegistry");
-const assertRevert = require("./helpers/assertRevert");
+const EthereumClaimsRegistry = artifacts.require('EthereumClaimsRegistry');
+const assertRevert = require('./helpers/assertRevert');
 
-contract("EthereumClaimsRegistry", accounts => {
-  it("Can Issue a claim", async () => {
-    const erc780 = await EthereumClaimsRegistry.deployed();
-    await erc780.setClaim(accounts[1], web3.sha3("Key"), web3.sha3("Value"), {
-      from: accounts[0]
-    });
-    assert.equal(
-      await erc780.getClaim(accounts[0], accounts[1], web3.sha3("Key")),
-      web3.sha3("Value")
-    );
-  });
-
-  it("Can Issue a Self-Claim", async () => {
-    const erc780 = await EthereumClaimsRegistry.deployed();
-    await erc780.setSelfClaim(web3.sha3("Key"), web3.sha3("Value"), {
-      from: accounts[0]
-    });
-    assert.equal(
-      await erc780.getClaim(accounts[0], accounts[0], web3.sha3("Key")),
-      web3.sha3("Value")
-    );
-  });
-
-  it("Can remove a Claim as Issuer", async () => {
-    const erc780 = await EthereumClaimsRegistry.deployed();
-    await erc780.setClaim(accounts[1], web3.sha3("Key"), web3.sha3("Value"), {
-      from: accounts[0]
+contract('EthereumClaimsRegistry', accounts => {
+    it('Can Issue a claim', async () => {
+        const erc780 = await EthereumClaimsRegistry.deployed();
+        await erc780.setClaim(accounts[1], web3.sha3('Key'), web3.sha3('Value'), {
+            from: accounts[0],
+        });
+        assert.equal(
+            await erc780.getClaim(accounts[0], accounts[1], web3.sha3('Key')),
+            web3.sha3('Value')
+        );
     });
 
-    await erc780.removeClaim(accounts[0], accounts[1], web3.sha3("Key"), {
-      from: accounts[0]
+    it('Can Issue a Self-Claim', async () => {
+        const erc780 = await EthereumClaimsRegistry.deployed();
+        await erc780.setSelfClaim(web3.sha3('Key'), web3.sha3('Value'), {
+            from: accounts[0],
+        });
+        assert.equal(
+            await erc780.getClaim(accounts[0], accounts[0], web3.sha3('Key')),
+            web3.sha3('Value')
+        );
     });
 
-    assert.equal(
-      await erc780.getClaim(accounts[0], accounts[1], web3.sha3("Key")),
-      0x0
-    );
-  });
+    it('Can remove a Claim as Issuer', async () => {
+        const erc780 = await EthereumClaimsRegistry.deployed();
+        await erc780.setClaim(accounts[1], web3.sha3('Key'), web3.sha3('Value'), {
+            from: accounts[0],
+        });
 
-  it("Can remove a Claim as Subject", async () => {
-    const erc780 = await EthereumClaimsRegistry.deployed();
-    await erc780.setClaim(accounts[1], web3.sha3("Key"), web3.sha3("Value"), {
-      from: accounts[0]
+        await erc780.removeClaim(accounts[0], accounts[1], web3.sha3('Key'), {
+            from: accounts[0],
+        });
+
+        assert.equal(
+            await erc780.getClaim(accounts[0], accounts[1], web3.sha3('Key')),
+            0x0
+        );
     });
 
-    await erc780.removeClaim(accounts[0], accounts[1], web3.sha3("Key"), {
-      from: accounts[1]
+    it('Can remove a Claim as Subject', async () => {
+        const erc780 = await EthereumClaimsRegistry.deployed();
+        await erc780.setClaim(accounts[1], web3.sha3('Key'), web3.sha3('Value'), {
+            from: accounts[0],
+        });
+
+        await erc780.removeClaim(accounts[0], accounts[1], web3.sha3('Key'), {
+            from: accounts[1],
+        });
+
+        assert.equal(
+            await erc780.getClaim(accounts[0], accounts[1], web3.sha3('Key')),
+            0x0
+        );
     });
 
-    assert.equal(
-      await erc780.getClaim(accounts[0], accounts[1], web3.sha3("Key")),
-      0x0
-    );
-  });
+    it('Can\'t remove a Claim if not a Subject or Issuer', async () => {
+        const erc780 = await EthereumClaimsRegistry.deployed();
+        await erc780.setClaim(accounts[1], web3.sha3('Key'), web3.sha3('Value'), {
+            from: accounts[0],
+        });
 
-  it("Can't remove a Claim if not a Subject or Issuer", async () => {
-    const erc780 = await EthereumClaimsRegistry.deployed();
-    await erc780.setClaim(accounts[1], web3.sha3("Key"), web3.sha3("Value"), {
-      from: accounts[0]
+        try {
+            await erc780.removeClaim(accounts[0], accounts[1], web3.sha3('Key'), {
+                from: accounts[2],
+            });
+            assert.fail('should have thrown before');
+        } catch (error) {
+            assertRevert(error);
+        }
+
+        assert.equal(
+            await erc780.getClaim(accounts[0], accounts[1], web3.sha3('Key')),
+            web3.sha3('Value')
+        );
     });
-
-    try {
-      await erc780.removeClaim(accounts[0], accounts[1], web3.sha3("Key"), {
-        from: accounts[2]
-      });
-      assert.fail("should have thrown before");
-    } catch (error) {
-      assertRevert(error);
-    }
-
-    assert.equal(
-      await erc780.getClaim(accounts[0], accounts[1], web3.sha3("Key")),
-      web3.sha3("Value")
-    );
-  });
 });

--- a/blockchain/test/helpers/assertRevert.js
+++ b/blockchain/test/helpers/assertRevert.js
@@ -1,7 +1,7 @@
 module.exports = function(error) {
-  assert.isAbove(
-    error.message.search("revert"),
-    -1,
-    "Revert error must be returned"
-  );
+    assert.isAbove(
+        error.message.search('revert'),
+        -1,
+        'Revert error must be returned'
+    );
 };

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -384,6 +384,30 @@ contract('address registration (fail)', function(accounts) {
                 );
         });
     });
+
+    contract('', () => {
+        it('registerAddress should fail if address was already registered', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+
+            let addresses = await popa.totalAddresses();
+            assert.equal(+addresses, 0);
+
+            await registerAddress(popa, args, accounts[0]);
+
+            addresses = await popa.totalAddresses();
+            assert.equal(+addresses, 1);
+
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 1);
+                    }
+                );
+        });
+    });
 });
 
 contract('address removal', function(accounts) {

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -88,9 +88,6 @@ contract('address registration (success)', function(accounts) {
             const popa = await ProofOfPhysicalAddress.deployed();
             const args = buildRegisterAddressArgs(accounts[0]);
 
-            let confirmed = await popa.totalConfirmed();
-            assert.equal(+confirmed, 0);
-
             await registerAddress(popa, args, accounts[0]);
 
             const [country, state, city, location, zip] = await popa.userAddress(accounts[0], 0);
@@ -100,6 +97,105 @@ contract('address registration (success)', function(accounts) {
             assert.equal(city, args.city);
             assert.equal(location, args.address);
             assert.equal(zip, args.zip);
+        });
+    });
+
+    contract('', () => {
+        it('should allow a user to register two different addresses', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args1 = buildRegisterAddressArgs(accounts[0]);
+
+            let addresses = await popa.totalAddresses();
+            let users = await popa.totalUsers();
+            let confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 0);
+            assert.equal(+users, 0);
+            assert.equal(+confirmed, 0);
+
+            await registerAddress(popa, args1, accounts[0]);
+
+            addresses = await popa.totalAddresses();
+            users = await popa.totalUsers();
+            confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 1);
+            assert.equal(+users, 1);
+            assert.equal(+confirmed, 0);
+
+            const args2 = buildRegisterAddressArgs(accounts[0], { state: 'al' });
+            await registerAddress(popa, args2, accounts[0]);
+
+            addresses = await popa.totalAddresses();
+            users = await popa.totalUsers();
+            confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 2);
+            assert.equal(+users, 1);
+            assert.equal(+confirmed, 0);
+        });
+    });
+
+    contract('', () => {
+        it('should allow different users to register different addresses', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args1 = buildRegisterAddressArgs(accounts[0]);
+
+            let addresses = await popa.totalAddresses();
+            let users = await popa.totalUsers();
+            let confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 0);
+            assert.equal(+users, 0);
+            assert.equal(+confirmed, 0);
+
+            await registerAddress(popa, args1, accounts[0]);
+
+            addresses = await popa.totalAddresses();
+            users = await popa.totalUsers();
+            confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 1);
+            assert.equal(+users, 1);
+            assert.equal(+confirmed, 0);
+
+            const args2 = buildRegisterAddressArgs(accounts[1], { address: '742 evergreen terrace' });
+            await registerAddress(popa, args2, accounts[1]);
+
+            addresses = await popa.totalAddresses();
+            users = await popa.totalUsers();
+            confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 2);
+            assert.equal(+users, 2);
+            assert.equal(+confirmed, 0);
+        });
+    });
+
+    contract('', () => {
+        it('should allow different users to register the same address', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args1 = buildRegisterAddressArgs(accounts[0]);
+
+            let addresses = await popa.totalAddresses();
+            let users = await popa.totalUsers();
+            let confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 0);
+            assert.equal(+users, 0);
+            assert.equal(+confirmed, 0);
+
+            await registerAddress(popa, args1, accounts[0]);
+
+            addresses = await popa.totalAddresses();
+            users = await popa.totalUsers();
+            confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 1);
+            assert.equal(+users, 1);
+            assert.equal(+confirmed, 0);
+
+            const args2 = buildRegisterAddressArgs(accounts[1]);
+            await registerAddress(popa, args2, accounts[1]);
+
+            addresses = await popa.totalAddresses();
+            users = await popa.totalUsers();
+            confirmed = await popa.totalConfirmed();
+            assert.equal(+addresses, 2);
+            assert.equal(+users, 2);
+            assert.equal(+confirmed, 0);
         });
     });
 });

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -902,6 +902,59 @@ contract('withdrawals', function(accounts) {
     });
 });
 
+contract('setSigner', function(accounts) {
+    contract('', () => {
+        it('should allow the owner to change the signer', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+
+            const signerBefore = await popa.signer();
+
+            await popa.setSigner(accounts[1]);
+
+            const signerAfter= await popa.signer();
+
+            assert.notEqual(signerBefore, signerAfter);
+            assert.equal(accounts[1], signerAfter);
+        });
+    });
+
+    contract('', () => {
+        it('should not allow someone that\'s not the owner to change the signer', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+
+            const signerBefore = await popa.signer();
+
+            await popa.setSigner(accounts[2], { from: accounts[1] })
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const signerAfter= await popa.signer();
+
+                        assert.equal(signerBefore, signerAfter);
+                    }
+                );
+        });
+    });
+
+    contract('', () => {
+        it('signerIsValid should change its result after the signer is changed', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+
+            const { v, r, s } = sign('foobar', privateKeys[0]);
+
+            const data = web3.sha3('foobar', { encoding: 'hex' });
+
+            const resultBefore = await popa.signerIsValid(data, v, r, s);
+            assert.isTrue(resultBefore);
+
+            await popa.setSigner(accounts[1]);
+
+            const resultAfter = await popa.signerIsValid(data, v, r, s);
+            assert.isFalse(resultAfter);
+        });
+    });
+});
+
 /**
  * Build arguments for registerAddress method
  *

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -5,487 +5,487 @@ const ProofOfPhysicalAddress = artifacts.require('ProofOfPhysicalAddress');
 // `solidity-coverage`
 let buildSignature = null;
 try {
-  buildSignature = require('../web-dapp/server-lib/buildSignature')
+    buildSignature = require('../web-dapp/server-lib/buildSignature');
 } catch (e) {
-  try {
-    buildSignature = require('../../web-dapp/server-lib/buildSignature')
-  } catch (e) {
-    buildSignature = require('../../../web-dapp/server-lib/buildSignature')
-  }
+    try {
+        buildSignature = require('../../web-dapp/server-lib/buildSignature');
+    } catch (e) {
+        buildSignature = require('../../../web-dapp/server-lib/buildSignature');
+    }
 }
 
 // Private keys of accounts generated when running `npm run start-testrpc`
 const privateKeys = [
-  '68d90a98fc4b8e66a016f66cb8363904a4e521a2480602bd78cc67945676e9cd',
-  '1dd9083e16e190fa5413f87837025556063c546bf16e38cc53fd5d018a3acfbb',
-  'a2fbd494c3031335d595cc5ad89a9c97d3e5a7f6b00d191d91af915b8b039d34',
-  'ed8aa8f379bac1ff5eafc5f792c32b40a5419edf528a37addbfc8ce36c487463',
-  '81193e26e271a824fda36511b2814e9d47e0c16ebd31304e88c25a6d659286b8',
-  '6ee2f0da244d4eea41bd2d92eb8af046589956790ca83055d72d6cb3fe425a57',
-  'b66c237da44e8f9d4411fa9b15c6d6e2df81f93bc5f03430895ccb5cc0a6aff9',
-  '27d7d3598f704da770bb126df3f7b073809ce2ea8cd0d7b75a409e320bf31b05',
-  '9095ed8f4917235794b9c4fe9438fec29de759916bf216a8aa28f647664a35ff',
-  'ab470a1366c59dec4058af0110d6447addf1bad57965bff5b01059cbd80ac47f'
-]
+    '68d90a98fc4b8e66a016f66cb8363904a4e521a2480602bd78cc67945676e9cd',
+    '1dd9083e16e190fa5413f87837025556063c546bf16e38cc53fd5d018a3acfbb',
+    'a2fbd494c3031335d595cc5ad89a9c97d3e5a7f6b00d191d91af915b8b039d34',
+    'ed8aa8f379bac1ff5eafc5f792c32b40a5419edf528a37addbfc8ce36c487463',
+    '81193e26e271a824fda36511b2814e9d47e0c16ebd31304e88c25a6d659286b8',
+    '6ee2f0da244d4eea41bd2d92eb8af046589956790ca83055d72d6cb3fe425a57',
+    'b66c237da44e8f9d4411fa9b15c6d6e2df81f93bc5f03430895ccb5cc0a6aff9',
+    '27d7d3598f704da770bb126df3f7b073809ce2ea8cd0d7b75a409e320bf31b05',
+    '9095ed8f4917235794b9c4fe9438fec29de759916bf216a8aa28f647664a35ff',
+    'ab470a1366c59dec4058af0110d6447addf1bad57965bff5b01059cbd80ac47f',
+];
 
-contract('ownership', (accounts) => {
-  it('signer should be equal to owner', async () => {
-    const popa = await ProofOfPhysicalAddress.deployed();
-    const owner = await popa.owner()
-    const signer = await popa.signer()
-    assert.equal(owner, signer)
-  });
-})
+contract('ownership', () => {
+    it('signer should be equal to owner', async () => {
+        const popa = await ProofOfPhysicalAddress.deployed();
+        const owner = await popa.owner();
+        const signer = await popa.signer();
+        assert.equal(owner, signer);
+    });
+});
 
 contract('address registration (success)', function(accounts) {
-  contract('', () => {
-    it('registerAddress should register an address', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('registerAddress should register an address', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      let addresses = await popa.totalAddresses()
-      assert.equal(+addresses, 0)
+            let addresses = await popa.totalAddresses();
+            assert.equal(+addresses, 0);
 
-      await registerAddress(popa, args, accounts[0])
+            await registerAddress(popa, args, accounts[0]);
 
-      addresses = await popa.totalAddresses()
-      assert.equal(+addresses, 1)
-    })
-  })
+            addresses = await popa.totalAddresses();
+            assert.equal(+addresses, 1);
+        });
+    });
 
-  contract('', () => {
-    it('total_users should be incremented if it\'s the first address for that user', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('total_users should be incremented if it\'s the first address for that user', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      let users = await popa.totalUsers()
-      assert.equal(+users, 0)
+            let users = await popa.totalUsers();
+            assert.equal(+users, 0);
 
-      await registerAddress(popa, args, accounts[0])
+            await registerAddress(popa, args, accounts[0]);
 
-      users = await popa.totalUsers()
-      assert.equal(+users, 1)
-    })
-  })
+            users = await popa.totalUsers();
+            assert.equal(+users, 1);
+        });
+    });
 
-  contract('', () => {
-    it('total_confirmed should not change after registering an address', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('total_confirmed should not change after registering an address', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      let confirmed = await popa.totalConfirmed()
-      assert.equal(+confirmed, 0)
+            let confirmed = await popa.totalConfirmed();
+            assert.equal(+confirmed, 0);
 
-      await registerAddress(popa, args, accounts[0])
+            await registerAddress(popa, args, accounts[0]);
 
-      confirmed = await popa.totalConfirmed()
-      assert.equal(+confirmed, 0)
-    })
-  })
+            confirmed = await popa.totalConfirmed();
+            assert.equal(+confirmed, 0);
+        });
+    });
 
-  contract('', () => {
-    it('registered address should have the proper structure', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('registered address should have the proper structure', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      let confirmed = await popa.totalConfirmed()
-      assert.equal(+confirmed, 0)
+            let confirmed = await popa.totalConfirmed();
+            assert.equal(+confirmed, 0);
 
-      await registerAddress(popa, args, accounts[0])
+            await registerAddress(popa, args, accounts[0]);
 
-      const [country, state, city, location, zip] = await popa.userAddress(accounts[0], 0)
+            const [country, state, city, location, zip] = await popa.userAddress(accounts[0], 0);
 
-      assert.equal(country, args.country)
-      assert.equal(state, args.state)
-      assert.equal(city, args.city)
-      assert.equal(location, args.address)
-      assert.equal(zip, args.zip)
-    })
-  })
-})
+            assert.equal(country, args.country);
+            assert.equal(state, args.state);
+            assert.equal(city, args.city);
+            assert.equal(location, args.address);
+            assert.equal(zip, args.zip);
+        });
+    });
+});
 
 contract('address registration (fail)', function(accounts) {
-  contract('', () => {
-    it('registerAddress should fail if name is empty', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0], { name: '' })
+    contract('', () => {
+        it('registerAddress should fail if name is empty', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0], { name: '' });
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if country is empty', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0], { country: '' })
+    contract('', () => {
+        it('registerAddress should fail if country is empty', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0], { country: '' });
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if state is empty', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0], { state: '' })
+    contract('', () => {
+        it('registerAddress should fail if state is empty', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0], { state: '' });
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if city is empty', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0], { city: '' })
+    contract('', () => {
+        it('registerAddress should fail if city is empty', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0], { city: '' });
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if address is empty', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0], { address: '' })
+    contract('', () => {
+        it('registerAddress should fail if address is empty', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0], { address: '' });
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if zip code is empty', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0], { zip: '' })
+    contract('', () => {
+        it('registerAddress should fail if zip code is empty', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0], { zip: '' });
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if sent value is not enough', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('registerAddress should fail if sent value is not enough', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      await registerAddress(popa, args, accounts[0], '39999999999999999')
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0], '39999999999999999')
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if sender is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('registerAddress should fail if sender is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      await registerAddress(popa, args, accounts[1])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[1])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if name is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.name += '!'
+    contract('', () => {
+        it('registerAddress should fail if name is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.name += '!';
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if country is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.country = 'ar'
+    contract('', () => {
+        it('registerAddress should fail if country is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.country = 'ar';
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if state is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.state = 'al'
+    contract('', () => {
+        it('registerAddress should fail if state is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.state = 'al';
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if city is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.city = 'new york'
+    contract('', () => {
+        it('registerAddress should fail if city is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.city = 'new york';
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if location is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.address = '742 evergreen terrace'
+    contract('', () => {
+        it('registerAddress should fail if location is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.address = '742 evergreen terrace';
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if zip is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.zip = '12345'
+    contract('', () => {
+        it('registerAddress should fail if zip is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.zip = '12345';
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if price is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.priceWei = '10'
+    contract('', () => {
+        it('registerAddress should fail if price is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.priceWei = '10';
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if sha3 is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
-      args.sha3cc = web3.sha3('foobar')
+    contract('', () => {
+        it('registerAddress should fail if sha3 is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
+            args.sha3cc = web3.sha3('foobar');
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
 
-  contract('', () => {
-    it('registerAddress should fail if args were signed with a different private key is different', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0], {}, privateKeys[1])
+    contract('', () => {
+        it('registerAddress should fail if args were signed with a different private key is different', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0], {}, privateKeys[1]);
 
-      await registerAddress(popa, args, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          async () => {
-            const addresses = await popa.totalAddresses()
-            assert.equal(+addresses, 0)
-          }
-        )
-    })
-  })
-})
+            await registerAddress(popa, args, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const addresses = await popa.totalAddresses();
+                        assert.equal(+addresses, 0);
+                    }
+                );
+        });
+    });
+});
 
 contract('address removal', function(accounts) {
-  contract('', () => {
-    it('should allow to unregister an address', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('should allow to unregister an address', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      await registerAddress(popa, args, accounts[0])
+            await registerAddress(popa, args, accounts[0]);
 
-      let addressesCount = await popa.userSubmittedAddressesCount(accounts[0])
-      assert.equal(+addressesCount, 1)
+            let addressesCount = await popa.userSubmittedAddressesCount(accounts[0]);
+            assert.equal(+addressesCount, 1);
 
-      await unregisterAddress(popa, args, accounts[0])
+            await unregisterAddress(popa, args, accounts[0]);
 
-      addressesCount = await popa.userSubmittedAddressesCount(accounts[0])
-      assert.equal(+addressesCount, 0)
-    })
-  })
+            addressesCount = await popa.userSubmittedAddressesCount(accounts[0]);
+            assert.equal(+addressesCount, 0);
+        });
+    });
 
-  contract('', () => {
-    it('should not allow an user to unregister another user\'s address', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('should not allow an user to unregister another user\'s address', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      await registerAddress(popa, args, accounts[0])
+            await registerAddress(popa, args, accounts[0]);
 
-      let addressesCount = await popa.userSubmittedAddressesCount(accounts[0])
-      assert.equal(+addressesCount, 1)
+            let addressesCount = await popa.userSubmittedAddressesCount(accounts[0]);
+            assert.equal(+addressesCount, 1);
 
-      await unregisterAddress(popa, args, accounts[1])
-        .then(
-          () => assert.fail(), // should reject
-          () => {}
-        )
+            await unregisterAddress(popa, args, accounts[1])
+                .then(
+                    () => assert.fail(), // should reject
+                    () => {}
+                );
 
-      addressesCount = await popa.userSubmittedAddressesCount(accounts[0])
-      assert.equal(+addressesCount, 1)
-    })
-  })
+            addressesCount = await popa.userSubmittedAddressesCount(accounts[0]);
+            assert.equal(+addressesCount, 1);
+        });
+    });
 
-  contract('', () => {
-    it('should delete the user if the unregistered address was their last one', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args = buildRegisterAddressArgs(accounts[0])
+    contract('', () => {
+        it('should delete the user if the unregistered address was their last one', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args = buildRegisterAddressArgs(accounts[0]);
 
-      await registerAddress(popa, args, accounts[0])
+            await registerAddress(popa, args, accounts[0]);
 
-      let userExists = await popa.userExists(accounts[0])
-      assert.isTrue(userExists)
+            let userExists = await popa.userExists(accounts[0]);
+            assert.isTrue(userExists);
 
-      await unregisterAddress(popa, args, accounts[0])
+            await unregisterAddress(popa, args, accounts[0]);
 
-      userExists = await popa.userExists(accounts[0])
-      assert.isFalse(userExists)
-    })
-  })
+            userExists = await popa.userExists(accounts[0]);
+            assert.isFalse(userExists);
+        });
+    });
 
-  contract('', () => {
-    it('should not delete the user if the unregistered address was not their last one', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args1 = buildRegisterAddressArgs(accounts[0])
-      const args2 = buildRegisterAddressArgs(accounts[0], {
-        address: '186 berry st'
-      })
+    contract('', () => {
+        it('should not delete the user if the unregistered address was not their last one', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args1 = buildRegisterAddressArgs(accounts[0]);
+            const args2 = buildRegisterAddressArgs(accounts[0], {
+                address: '186 berry st',
+            });
 
-      await registerAddress(popa, args1, accounts[0])
-      await registerAddress(popa, args2, accounts[0])
+            await registerAddress(popa, args1, accounts[0]);
+            await registerAddress(popa, args2, accounts[0]);
 
-      let userExists = await popa.userExists(accounts[0])
-      assert.isTrue(userExists)
+            let userExists = await popa.userExists(accounts[0]);
+            assert.isTrue(userExists);
 
-      await unregisterAddress(popa, args1, accounts[0])
+            await unregisterAddress(popa, args1, accounts[0]);
 
-      userExists = await popa.userExists(accounts[0])
-      assert.isTrue(userExists)
-    })
-  })
+            userExists = await popa.userExists(accounts[0]);
+            assert.isTrue(userExists);
+        });
+    });
 
-  contract('', () => {
-    it('should not delete an address that an user has not registered', async () => {
-      const popa = await ProofOfPhysicalAddress.deployed();
-      const args1 = buildRegisterAddressArgs(accounts[0])
-      const args2 = buildRegisterAddressArgs(accounts[0], {
-        address: '186 berry st'
-      })
+    contract('', () => {
+        it('should not delete an address that an user has not registered', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+            const args1 = buildRegisterAddressArgs(accounts[0]);
+            const args2 = buildRegisterAddressArgs(accounts[0], {
+                address: '186 berry st',
+            });
 
-      await registerAddress(popa, args1, accounts[0])
+            await registerAddress(popa, args1, accounts[0]);
 
-      let addressesCount = await popa.userSubmittedAddressesCount(accounts[0])
-      assert.equal(+addressesCount, 1)
+            let addressesCount = await popa.userSubmittedAddressesCount(accounts[0]);
+            assert.equal(+addressesCount, 1);
 
-      await unregisterAddress(popa, args2, accounts[0])
-        .then(
-          () => assert.fail(), // should reject
-          () => {}
-        )
+            await unregisterAddress(popa, args2, accounts[0])
+                .then(
+                    () => assert.fail(), // should reject
+                    () => {}
+                );
 
-      addressesCount = await popa.userSubmittedAddressesCount(accounts[0])
-      assert.equal(+addressesCount, 1)
-    })
-  })
+            addressesCount = await popa.userSubmittedAddressesCount(accounts[0]);
+            assert.equal(+addressesCount, 1);
+        });
+    });
 });
 
 /**
@@ -496,59 +496,59 @@ contract('address removal', function(accounts) {
  * 0x7e7693f12bfd372042b754b729d1474572a2dd01
  */
 function buildRegisterAddressArgs(account, extraArgs = {}, privateKey = privateKeys[0]) {
-  const baseArgs = {
-    wallet: account,
-    name: 'john doe',
-    country: 'us',
-    state: 'ca',
-    city: 'san francisco',
-    address: '185 berry st',
-    zip: '94107',
-    priceWei: '40000000000000000',
-    cc: '8hwpyynkd9'
-  }
+    const baseArgs = {
+        wallet: account,
+        name: 'john doe',
+        country: 'us',
+        state: 'ca',
+        city: 'san francisco',
+        address: '185 berry st',
+        zip: '94107',
+        priceWei: '40000000000000000',
+        cc: '8hwpyynkd9',
+    };
 
-  const args = Object.assign(baseArgs, extraArgs)
+    const args = Object.assign(baseArgs, extraArgs);
 
-  args.sha3cc = web3.sha3(args.cc)
+    args.sha3cc = web3.sha3(args.cc);
 
-  const { v, r, s } = buildSignature(args, privateKey)
-  args.sigV = v
-  args.sigR = r
-  args.sigS = s
+    const { v, r, s } = buildSignature(args, privateKey);
+    args.sigV = v;
+    args.sigR = r;
+    args.sigS = s;
 
-  return args
+    return args;
 }
 
 function registerAddress(popa, args, account, value = args.priceWei) {
-  return popa.registerAddress(
-    args.name,
-    args.country,
-    args.state,
-    args.city,
-    args.address,
-    args.zip,
-    args.priceWei,
-    args.sha3cc,
-    args.sigV,
-    args.sigR,
-    args.sigS,
-    {
-      from: account,
-      value: value
-    }
-  )
+    return popa.registerAddress(
+        args.name,
+        args.country,
+        args.state,
+        args.city,
+        args.address,
+        args.zip,
+        args.priceWei,
+        args.sha3cc,
+        args.sigV,
+        args.sigR,
+        args.sigS,
+        {
+            from: account,
+            value: value,
+        }
+    );
 }
 
 function unregisterAddress(popa, args, account) {
-  return popa.unregisterAddress(
-    args.country,
-    args.state,
-    args.city,
-    args.address,
-    args.zip,
-    {
-      from: account
-    }
-  )
+    return popa.unregisterAddress(
+        args.country,
+        args.state,
+        args.city,
+        args.address,
+        args.zip,
+        {
+            from: account,
+        }
+    );
 }

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -938,6 +938,41 @@ contract('setSigner', function(accounts) {
     });
 });
 
+contract('setRegistry', function(accounts) {
+    contract('', () => {
+        it('should allow the owner to change the registry', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+
+            const registryBefore = await popa.registry();
+
+            await popa.setRegistry('0xfedcbafedcbafedcbafedcbafedcbafedcbafdec');
+
+            const registryAfter= await popa.registry();
+
+            assert.notEqual(registryBefore, registryAfter);
+            assert.equal(registryAfter, '0xfedcbafedcbafedcbafedcbafedcbafedcbafdec');
+        });
+    });
+
+    contract('', () => {
+        it('should not allow someone that\'s not the owner to change the registry', async () => {
+            const popa = await ProofOfPhysicalAddress.deployed();
+
+            const registryBefore = await popa.registry();
+
+            await popa.setRegistry( '0xfedcbafedcbafedcbafedcbafedcbafedcbafdec', { from: accounts[1] })
+                .then(
+                    () => assert.fail(), // should reject
+                    async () => {
+                        const registryAfter= await popa.registry();
+
+                        assert.equal(registryBefore, registryAfter);
+                    }
+                );
+        });
+    });
+});
+
 contract('helpers', function(accounts) {
     // userExists
     contract('', () => {

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -316,6 +316,22 @@ contract('address registration', function(accounts) {
         )
     })
   })
+
+  contract('', () => {
+    it('registerAddress should fail if args were signed with a different private key is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0], {}, privateKeys[1])
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
 })
 
 contract('address removal', function(accounts) {
@@ -427,7 +443,7 @@ contract('address removal', function(accounts) {
  * 1dd9083e16e190fa5413f87837025556063c546bf16e38cc53fd5d018a3acfbb, for the requester address
  * 0x7e7693f12bfd372042b754b729d1474572a2dd01
  */
-function buildRegisterAddressArgs(account, extraArgs = {}) {
+function buildRegisterAddressArgs(account, extraArgs = {}, privateKey = privateKeys[0]) {
   const baseArgs = {
     wallet: account,
     name: 'john doe',
@@ -444,7 +460,7 @@ function buildRegisterAddressArgs(account, extraArgs = {}) {
 
   args.sha3cc = web3.sha3(args.cc)
 
-  const { v, r, s } = buildSignature(args, privateKeys[0])
+  const { v, r, s } = buildSignature(args, privateKey)
   args.sigV = v
   args.sigR = r
   args.sigS = s

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -166,6 +166,160 @@ contract('address registration', function(accounts) {
   })
 
   contract('', () => {
+    it('registerAddress should fail if sender is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+
+      await registerAddress(popa, args, accounts[1])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if name is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.name += '!'
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if country is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.country = 'ar'
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if state is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.state = 'al'
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if city is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.city = 'new york'
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if location is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.address = '742 evergreen terrace'
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if zip is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.zip = '12345'
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if price is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.priceWei = '10'
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+
+  contract('', () => {
+    it('registerAddress should fail if sha3 is different', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+      args.sha3cc = web3.sha3('foobar')
+
+      await registerAddress(popa, args, accounts[0])
+        .then(
+          () => assert.fail(), // should reject
+          async () => {
+            const addresses = await popa.totalAddresses()
+            assert.equal(+addresses, 0)
+          }
+        )
+    })
+  })
+})
+
+contract('address removal', function(accounts) {
+  contract('', () => {
     it('should allow to unregister an address', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
       const args = buildRegisterAddressArgs(accounts[0])

--- a/blockchain/test/proof_of_physical_address.js
+++ b/blockchain/test/proof_of_physical_address.js
@@ -37,7 +37,7 @@ contract('ownership', (accounts) => {
   });
 })
 
-contract('address registration', function(accounts) {
+contract('address registration (success)', function(accounts) {
   contract('', () => {
     it('registerAddress should register an address', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();
@@ -53,6 +53,58 @@ contract('address registration', function(accounts) {
     })
   })
 
+  contract('', () => {
+    it('total_users should be incremented if it\'s the first address for that user', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+
+      let users = await popa.totalUsers()
+      assert.equal(+users, 0)
+
+      await registerAddress(popa, args, accounts[0])
+
+      users = await popa.totalUsers()
+      assert.equal(+users, 1)
+    })
+  })
+
+  contract('', () => {
+    it('total_confirmed should not change after registering an address', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+
+      let confirmed = await popa.totalConfirmed()
+      assert.equal(+confirmed, 0)
+
+      await registerAddress(popa, args, accounts[0])
+
+      confirmed = await popa.totalConfirmed()
+      assert.equal(+confirmed, 0)
+    })
+  })
+
+  contract('', () => {
+    it('registered address should have the proper structure', async () => {
+      const popa = await ProofOfPhysicalAddress.deployed();
+      const args = buildRegisterAddressArgs(accounts[0])
+
+      let confirmed = await popa.totalConfirmed()
+      assert.equal(+confirmed, 0)
+
+      await registerAddress(popa, args, accounts[0])
+
+      const [country, state, city, location, zip] = await popa.userAddress(accounts[0], 0)
+
+      assert.equal(country, args.country)
+      assert.equal(state, args.state)
+      assert.equal(city, args.city)
+      assert.equal(location, args.address)
+      assert.equal(zip, args.zip)
+    })
+  })
+})
+
+contract('address registration (fail)', function(accounts) {
   contract('', () => {
     it('registerAddress should fail if name is empty', async () => {
       const popa = await ProofOfPhysicalAddress.deployed();

--- a/blockchain/truffle.js
+++ b/blockchain/truffle.js
@@ -1,31 +1,31 @@
-const HDWalletProvider = require("truffle-hdwallet-provider");
+const HDWalletProvider = require('truffle-hdwallet-provider');
 
-const mnemonic = 'toddler weather rocket off sentence chat unlock flame organ shuffle treat awful'
-const rinkebyUrl = 'https://rinkeby.infura.io'
+const mnemonic = 'toddler weather rocket off sentence chat unlock flame organ shuffle treat awful';
+const rinkebyUrl = 'https://rinkeby.infura.io';
 
 module.exports = {
-  networks: {
-    development: {
-      host: '127.0.0.1',
-      port: 8545,
-      network_id: '*'
+    networks: {
+        development: {
+            host: '127.0.0.1',
+            port: 8545,
+            network_id: '*',
+        },
+        test: {
+            host: '127.0.0.1',
+            port: 8545,
+            network_id: '*',
+            gas: '5000000',
+        },
+        coverage: {
+            host: '127.0.0.1',
+            port: 8555,
+            network_id: '*',
+            gas: '0xfffffffffff',
+            gasPrice: 0x01,
+        },
+        rinkeby: {
+            provider: new HDWalletProvider(mnemonic, rinkebyUrl),
+            network_id: 4,
+        },
     },
-    test: {
-      host: '127.0.0.1',
-      port: 8545,
-      network_id: '*',
-      gas: '5000000'
-    },
-    coverage: {
-      host: '127.0.0.1',
-      port: 8555,
-      network_id: '*',
-      gas: '0xfffffffffff',
-      gasPrice: 0x01
-    },
-    rinkeby: {
-      provider: new HDWalletProvider(mnemonic, rinkebyUrl),
-      network_id: 4
-    }
-  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,29 @@
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
       "dev": true
     },
+    "acorn": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "dev": true,
+      "requires": {
+        "acorn": "3.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+          "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
@@ -21,6 +44,12 @@
         "fast-json-stable-stringify": "2.0.0",
         "json-schema-traverse": "0.3.1"
       }
+    },
+    "ajv-keywords": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
+      "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.1.0",
@@ -57,6 +86,16 @@
         "sprintf-js": "1.0.3"
       }
     },
+    "aria-query": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-0.7.1.tgz",
+      "integrity": "sha1-Jsu1r/ZBRLCoJb4YRuCxbPoAsR4=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7",
+        "commander": "2.15.1"
+      }
+    },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
@@ -77,6 +116,16 @@
       "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
       "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
       "dev": true
+    },
+    "array-includes": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.0.3.tgz",
+      "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.11.0"
+      }
     },
     "array-union": {
       "version": "1.0.2",
@@ -105,6 +154,12 @@
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
       "dev": true
     },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "dev": true
+    },
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
@@ -121,6 +176,12 @@
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.3.tgz",
       "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
+      "dev": true
+    },
+    "ast-types-flow": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+      "integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0=",
       "dev": true
     },
     "async": {
@@ -146,6 +207,15 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
       "dev": true
+    },
+    "axobject-query": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-0.1.0.tgz",
+      "integrity": "sha1-YvWdvFnJ+SQnWco0mWDnov48NsA=",
+      "dev": true,
+      "requires": {
+        "ast-types-flow": "0.0.7"
+      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -1103,6 +1173,12 @@
         "repeat-element": "1.1.2"
       }
     },
+    "buffer-from": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
+      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1130,6 +1206,21 @@
           "dev": true
         }
       }
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "dev": true,
+      "requires": {
+        "callsites": "0.2.0"
+      }
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+      "dev": true
     },
     "camelcase": {
       "version": "3.0.0",
@@ -1164,6 +1255,22 @@
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
       "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
       "dev": true
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+      "dev": true
+    },
+    "cli": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
+      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
+      "dev": true,
+      "requires": {
+        "exit": "0.1.2",
+        "glob": "7.1.2"
+      }
     },
     "cli-cursor": {
       "version": "2.1.0",
@@ -1310,6 +1417,12 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "commander": {
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1326,6 +1439,27 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+    },
+    "concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "requires": {
+        "buffer-from": "1.0.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.4",
+        "typedarray": "0.0.6"
+      }
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+      "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+      "dev": true,
+      "requires": {
+        "date-now": "0.1.4"
+      }
     },
     "convert-source-map": {
       "version": "1.5.1",
@@ -1410,6 +1544,12 @@
       "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.1.8.tgz",
       "integrity": "sha1-cV8HC/YBTyrpkqmLOSkli3E/CNU="
     },
+    "damerau-levenshtein": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.4.tgz",
+      "integrity": "sha1-AxkcQyy27qFou3fzpV/9zLiXhRQ=",
+      "dev": true
+    },
     "dargs": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dargs/-/dargs-5.1.0.tgz",
@@ -1429,6 +1569,12 @@
       "version": "1.29.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
       "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
+    "date-now": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+      "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
     "dateformat": {
@@ -1472,6 +1618,53 @@
       "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
       "dev": true
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
+    },
+    "del": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "dev": true,
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.1",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.2"
+      },
+      "dependencies": {
+        "globby": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+          "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "arrify": "1.0.1",
+            "glob": "7.1.2",
+            "object-assign": "4.1.1",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        }
+      }
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -1498,6 +1691,64 @@
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
       "dev": true
+    },
+    "doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "requires": {
+        "esutils": "2.0.2"
+      }
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.1.3",
+        "entities": "1.1.1"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+          "dev": true
+        },
+        "entities": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "dev": true
+        }
+      }
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
+      "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0"
+      }
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+      "dev": true,
+      "requires": {
+        "dom-serializer": "0.1.0",
+        "domelementtype": "1.3.0"
+      }
     },
     "duplexer3": {
       "version": "0.1.4",
@@ -1545,11 +1796,26 @@
       "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-6.5.1.tgz",
+      "integrity": "sha512-PAHp6TxrCy7MGMFidro8uikr+zlJJKJ/Q6mm2ExZ7HwkyR9lSVFfE3kt36qcwa24BQL7y0G9axycGjK1A/0uNQ==",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
       "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
       "dev": true
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.4.21"
+      }
     },
     "end-of-stream": {
       "version": "1.4.1",
@@ -1570,6 +1836,12 @@
         "memory-fs": "0.4.1",
         "tapable": "1.0.0"
       }
+    },
+    "entities": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
+      "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
+      "dev": true
     },
     "envinfo": {
       "version": "4.4.2",
@@ -1604,16 +1876,244 @@
         "is-arrayish": "0.2.1"
       }
     },
+    "es-abstract": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.11.0.tgz",
+      "integrity": "sha512-ZnQrE/lXTTQ39ulXZ+J1DTFazV9qBy61x2bY071B+qGco8Z8q1QddsLdt/EF8Ai9hcWH72dWS0kFqXLxOxqslA==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
+    "eslint": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+      "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "babel-code-frame": "6.26.0",
+        "chalk": "2.4.0",
+        "concat-stream": "1.6.2",
+        "cross-spawn": "5.1.0",
+        "debug": "3.1.0",
+        "doctrine": "2.1.0",
+        "eslint-scope": "3.7.1",
+        "eslint-visitor-keys": "1.0.0",
+        "espree": "3.5.4",
+        "esquery": "1.0.1",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "functional-red-black-tree": "1.0.1",
+        "glob": "7.1.2",
+        "globals": "11.4.0",
+        "ignore": "3.3.7",
+        "imurmurhash": "0.1.4",
+        "inquirer": "3.3.0",
+        "is-resolvable": "1.1.0",
+        "js-yaml": "3.10.0",
+        "json-stable-stringify-without-jsonify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.5",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "7.0.0",
+        "progress": "2.0.0",
+        "regexpp": "1.1.0",
+        "require-uncached": "1.0.3",
+        "semver": "5.5.0",
+        "strip-ansi": "4.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "4.0.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "4.1.2",
+            "shebang-command": "1.2.0",
+            "which": "1.3.0"
+          }
+        },
+        "globals": {
+          "version": "11.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-11.4.0.tgz",
+          "integrity": "sha512-Dyzmifil8n/TmSqYDEXbm+C8yitzJQqQIlJQLNRMwa+BOUJpRC19pyVeN12JAjt61xonvXjtff+hJruTRXn5HA==",
+          "dev": true
+        },
+        "inquirer": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+          "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+          "dev": true,
+          "requires": {
+            "ansi-escapes": "3.1.0",
+            "chalk": "2.4.0",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.2.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.5",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx-lite": "4.0.8",
+            "rx-lite-aggregates": "4.0.8",
+            "string-width": "2.1.1",
+            "strip-ansi": "4.0.0",
+            "through": "2.3.8"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-plugin-json": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.2.0.tgz",
+      "integrity": "sha1-m6c7sL6Z1QCT6In1uWhGPSow764=",
+      "dev": true,
+      "requires": {
+        "jshint": "2.9.5"
+      }
+    },
+    "eslint-plugin-jsx-a11y": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
+      "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
+      "dev": true,
+      "requires": {
+        "aria-query": "0.7.1",
+        "array-includes": "3.0.3",
+        "ast-types-flow": "0.0.7",
+        "axobject-query": "0.1.0",
+        "damerau-levenshtein": "1.0.4",
+        "emoji-regex": "6.5.1",
+        "jsx-ast-utils": "2.0.1"
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.7.0.tgz",
+      "integrity": "sha512-KC7Snr4YsWZD5flu6A5c0AcIZidzW3Exbqp7OT67OaD2AppJtlBr/GuPrW/vaQM/yfZotEvKAdrxrO+v8vwYJA==",
+      "dev": true,
+      "requires": {
+        "doctrine": "2.1.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "2.0.1",
+        "prop-types": "15.6.1"
+      }
+    },
+    "eslint-scope": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+      "dev": true,
+      "requires": {
+        "esrecurse": "4.2.1",
+        "estraverse": "4.2.0"
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+      "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+      "dev": true,
+      "requires": {
+        "acorn": "5.5.3",
+        "acorn-jsx": "3.0.1"
+      }
+    },
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
       "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "4.2.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
     "esutils": {
@@ -1649,6 +2149,12 @@
           }
         }
       }
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -1744,6 +2250,35 @@
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
       "dev": true
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "fbjs": {
+      "version": "0.8.16",
+      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.16.tgz",
+      "integrity": "sha1-XmdDL1UNxBtXK/VYR7ispk5TN9s=",
+      "dev": true,
+      "requires": {
+        "core-js": "1.2.7",
+        "isomorphic-fetch": "2.2.1",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "promise": "7.3.1",
+        "setimmediate": "1.0.5",
+        "ua-parser-js": "0.7.17"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=",
+          "dev": true
+        }
+      }
+    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -1751,6 +2286,16 @@
       "dev": true,
       "requires": {
         "escape-string-regexp": "1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "dev": true,
+      "requires": {
+        "flat-cache": "1.3.0",
+        "object-assign": "4.1.1"
       }
     },
     "filename-regex": {
@@ -1787,6 +2332,24 @@
       "integrity": "sha1-Wb+1DNkF9g18OUzT2ayqtOatk04=",
       "dev": true
     },
+    "flat-cache": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+      "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+      "dev": true,
+      "requires": {
+        "circular-json": "0.3.3",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
+    },
+    "flow-parser": {
+      "version": "0.70.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.70.0.tgz",
+      "integrity": "sha512-gGdyVUZWswG5jcINrVDHd3RY4nJptBTAx9mR9thGsrGGmAUR7omgJXQSpR+fXrLtxSTAea3HpAZNU/yzRJc2Cg==",
+      "dev": true
+    },
     "font-awesome": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz",
@@ -1806,6 +2369,12 @@
       "requires": {
         "for-in": "1.0.2"
       }
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -1856,6 +2425,18 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+    },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
     },
     "ganache-cli": {
       "version": "6.1.0",
@@ -2261,6 +2842,15 @@
         "har-schema": "2.0.0"
       }
     },
+    "has": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
+    },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -2339,6 +2929,45 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
       "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
+    "htmlparser2": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
+      "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
+      "dev": true,
+      "requires": {
+        "domelementtype": "1.3.0",
+        "domhandler": "2.3.0",
+        "domutils": "1.5.1",
+        "entities": "1.0.0",
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "dev": true,
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "http-cache-semantics": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
@@ -2375,6 +3004,12 @@
       "requires": {
         "safer-buffer": "2.1.2"
       }
+    },
+    "ignore": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+      "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -2524,6 +3159,12 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-callable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
+    },
     "is-ci": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
@@ -2532,6 +3173,12 @@
       "requires": {
         "ci-info": "1.1.2"
       }
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-dotfile": {
       "version": "1.0.3",
@@ -2618,6 +3265,30 @@
         }
       }
     },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "dev": true,
+      "requires": {
+        "is-path-inside": "1.0.1"
+      }
+    },
+    "is-path-inside": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+      "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
+    },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
@@ -2642,6 +3313,21 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
+    },
+    "is-resolvable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+      "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+      "dev": true
+    },
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
@@ -2661,6 +3347,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -2705,6 +3397,16 @@
       "dev": true,
       "requires": {
         "isarray": "1.0.0"
+      }
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
+      "dev": true,
+      "requires": {
+        "node-fetch": "1.7.3",
+        "whatwg-fetch": "2.0.4"
       }
     },
     "isstream": {
@@ -2786,6 +3488,42 @@
       "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
       "dev": true
     },
+    "jshint": {
+      "version": "2.9.5",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
+      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "dev": true,
+      "requires": {
+        "cli": "1.0.1",
+        "console-browserify": "1.1.0",
+        "exit": "0.1.2",
+        "htmlparser2": "3.8.3",
+        "lodash": "3.7.0",
+        "minimatch": "3.0.4",
+        "shelljs": "0.3.0",
+        "strip-json-comments": "1.0.4"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.7.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
+          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
+          "dev": true
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
+          "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
+          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "dev": true
+        }
+      }
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -2818,6 +3556,12 @@
       "requires": {
         "jsonify": "0.0.0"
       }
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -2855,6 +3599,15 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
+      "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
+      "dev": true,
+      "requires": {
+        "array-includes": "3.0.3"
       }
     },
     "keyv": {
@@ -2915,6 +3668,16 @@
         "through2": "2.0.3",
         "vinyl": "2.1.0",
         "vinyl-fs": "2.4.4"
+      }
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "listr": {
@@ -3520,6 +4283,12 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "neo-async": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
@@ -3537,6 +4306,16 @@
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.8.tgz",
       "integrity": "sha1-VfuN62mQcHB/tn+RpGDwRIKUx30=",
       "dev": true
+    },
+    "node-fetch": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+      "dev": true,
+      "requires": {
+        "encoding": "0.1.12",
+        "is-stream": "1.1.0"
+      }
     },
     "nomnom": {
       "version": "1.8.1",
@@ -3627,6 +4406,12 @@
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
       "dev": true
     },
+    "object-keys": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
+    },
     "object.omit": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
@@ -3652,6 +4437,20 @@
       "dev": true,
       "requires": {
         "mimic-fn": "1.2.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "ora": {
@@ -3888,6 +4687,12 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -3954,6 +4759,18 @@
         }
       }
     },
+    "pluralize": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+      "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
     "prepend-http": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
@@ -3989,6 +4806,32 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
       "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
       "dev": true
+    },
+    "progress": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+      "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
+      "dev": true,
+      "requires": {
+        "asap": "2.0.6"
+      }
+    },
+    "prop-types": {
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1"
+      }
     },
     "prr": {
       "version": "1.0.1",
@@ -4171,6 +5014,12 @@
         "is-equal-shallow": "0.1.3"
       }
     },
+    "regexpp": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+      "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
+      "dev": true
+    },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
@@ -4274,6 +5123,24 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "dev": true,
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      },
+      "dependencies": {
+        "resolve-from": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+          "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+          "dev": true
+        }
+      }
     },
     "resolve": {
       "version": "1.7.1",
@@ -4396,6 +5263,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -4645,6 +5518,12 @@
       "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
       "dev": true
     },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "superagent": {
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-3.8.2.tgz",
@@ -4687,6 +5566,62 @@
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
       "dev": true
+    },
+    "table": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
+      "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
+      "dev": true,
+      "requires": {
+        "ajv": "5.5.2",
+        "ajv-keywords": "2.1.1",
+        "chalk": "2.4.0",
+        "lodash": "4.17.5",
+        "slice-ansi": "1.0.0",
+        "string-width": "2.1.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+          "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "3.0.0"
+          }
+        }
+      }
     },
     "tapable": {
       "version": "1.0.0",
@@ -4810,6 +5745,27 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true,
       "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.17",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
+      "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
+      "dev": true
     },
     "underscore": {
       "version": "1.6.0",
@@ -5136,6 +6092,12 @@
         "yeoman-generator": "2.0.4"
       }
     },
+    "whatwg-fetch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+      "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
+      "dev": true
+    },
     "which": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
@@ -5155,6 +6117,12 @@
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
       "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU="
     },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -5168,6 +6136,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "dev": true,
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "write-file-atomic": {
       "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "npm run build --prefix web-dapp",
     "coverage": "lcov-result-merger '?(blockchain|web-dapp)/coverage/lcov.info' | coveralls",
-    "lint": "npm run lint --prefix web-dapp",
+    "lint": "eslint .",
     "postinstall": "npm install --prefix web-dapp && npm install --prefix blockchain",
     "prepush": "npm run lint && npm test",
     "prestart": "npm run build",
@@ -23,6 +23,10 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.0",
+    "eslint": "^4.19.1",
+    "eslint-plugin-json": "^1.2.0",
+    "eslint-plugin-jsx-a11y": "^6.0.3",
+    "eslint-plugin-react": "^7.7.0",
     "ganache-cli": "^6.1.0",
     "husky": "^0.14.3",
     "lcov-result-merger": "^2.0.0",

--- a/web-dapp/package-lock.json
+++ b/web-dapp/package-lock.json
@@ -2215,16 +2215,6 @@
         }
       }
     },
-    "cli": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cli/-/cli-1.0.1.tgz",
-      "integrity": "sha1-IoF1NPJL+klQw01TLUjsvGIbjBQ=",
-      "dev": true,
-      "requires": {
-        "exit": "0.1.2",
-        "glob": "7.1.2"
-      }
-    },
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
@@ -3480,125 +3470,6 @@
         "estraverse": "4.2.0"
       }
     },
-    "eslint": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
-      "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.1",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.3",
-        "esquery": "1.0.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.3.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.4",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.4.1",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
-          "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "3.2.0",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.2.0"
-          }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
-          "dev": true
-        },
-        "globals": {
-          "version": "11.3.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
-          "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-          "dev": true
-        },
-        "js-yaml": {
-          "version": "3.10.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
-          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-          "dev": true,
-          "requires": {
-            "argparse": "1.0.9",
-            "esprima": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
-          "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-          "dev": true,
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        }
-      }
-    },
     "eslint-config-react-app": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-2.1.0.tgz",
@@ -3745,64 +3616,6 @@
         }
       }
     },
-    "eslint-plugin-json": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-json/-/eslint-plugin-json-1.2.0.tgz",
-      "integrity": "sha1-m6c7sL6Z1QCT6In1uWhGPSow764=",
-      "dev": true,
-      "requires": {
-        "jshint": "2.9.5"
-      }
-    },
-    "eslint-plugin-jsx-a11y": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.0.3.tgz",
-      "integrity": "sha1-VFg9GuRCSDFi4EDhPMMYZUZRAOU=",
-      "dev": true,
-      "requires": {
-        "aria-query": "0.7.1",
-        "array-includes": "3.0.3",
-        "ast-types-flow": "0.0.7",
-        "axobject-query": "0.1.0",
-        "damerau-levenshtein": "1.0.4",
-        "emoji-regex": "6.5.1",
-        "jsx-ast-utils": "2.0.1"
-      },
-      "dependencies": {
-        "jsx-ast-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-          "dev": true,
-          "requires": {
-            "array-includes": "3.0.3"
-          }
-        }
-      }
-    },
-    "eslint-plugin-react": {
-      "version": "7.6.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.6.1.tgz",
-      "integrity": "sha512-30aMOHWX/DOaaLJVBHz6RMvYM2qy5GH63+y2PLFdIrYe4YLtODFmT3N1YA7ZqUnaBweVbedr4K4cqxOlWAPjIw==",
-      "dev": true,
-      "requires": {
-        "doctrine": "2.1.0",
-        "has": "1.0.1",
-        "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.0"
-      },
-      "dependencies": {
-        "jsx-ast-utils": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.0.1.tgz",
-          "integrity": "sha1-6AGxs5mF4g//yHtA43SAgOLcrH8=",
-          "dev": true,
-          "requires": {
-            "array-includes": "3.0.3"
-          }
-        }
-      }
-    },
     "eslint-scope": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
@@ -3811,12 +3624,6 @@
         "esrecurse": "4.2.0",
         "estraverse": "4.2.0"
       }
-    },
-    "eslint-visitor-keys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
-      "dev": true
     },
     "espree": {
       "version": "3.5.3",
@@ -3928,12 +3735,6 @@
         "signal-exit": "3.0.2",
         "strip-eof": "1.0.0"
       }
-    },
-    "exit": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
-      "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
-      "dev": true
     },
     "expand-brackets": {
       "version": "0.1.5",
@@ -4748,7 +4549,8 @@
         "jsbn": {
           "version": "0.1.1",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -6971,82 +6773,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
       "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
     },
-    "jshint": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
-      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
-      "dev": true,
-      "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
-      },
-      "dependencies": {
-        "domhandler": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.3.0.tgz",
-          "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0"
-          }
-        },
-        "entities": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.0.0.tgz",
-          "integrity": "sha1-sph6o4ITR/zeZCsk/fyeT7cSvyY=",
-          "dev": true
-        },
-        "htmlparser2": {
-          "version": "3.8.3",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
-          "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
-          "dev": true,
-          "requires": {
-            "domelementtype": "1.3.0",
-            "domhandler": "2.3.0",
-            "domutils": "1.5.1",
-            "entities": "1.0.0",
-            "readable-stream": "1.1.14"
-          }
-        },
-        "lodash": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
-        "strip-json-comments": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
-          "dev": true
-        }
-      }
-    },
     "json-loader": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
@@ -7069,12 +6795,6 @@
       "requires": {
         "jsonify": "0.0.0"
       }
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -11155,12 +10875,6 @@
         "array-reduce": "0.0.0",
         "jsonify": "0.0.0"
       }
-    },
-    "shelljs": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz",
-      "integrity": "sha1-NZbmMHp4FUT1kfN9phg2DzHbV7E=",
-      "dev": true
     },
     "shellwords": {
       "version": "0.1.1",

--- a/web-dapp/package.json
+++ b/web-dapp/package.json
@@ -6,7 +6,6 @@
     "start": "react-scripts start",
     "build": "npm run build-css && react-scripts build",
     "build-css": "node-sass ./src/assets/stylesheets/application.scss ./src/assets/stylesheets/application.css",
-    "lint": "eslint .",
     "test": "react-scripts test --testMatch **/test/server/**/*.spec.js **/src/**/*.test.js --env=jsdom --coverage"
   },
   "dependencies": {
@@ -30,10 +29,6 @@
   "devDependencies": {
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-15": "^1.0.5",
-    "eslint": "^4.17.0",
-    "eslint-plugin-json": "^1.2.0",
-    "eslint-plugin-jsx-a11y": "^6.0.3",
-    "eslint-plugin-react": "^7.6.1",
     "node-sass": "^4.8.3",
     "react-test-renderer": "^15.6.2",
     "sinon": "^4.3.0",


### PR DESCRIPTION
Part of #15 and #118.

Add all missing tests for the PoPA contract. This takes the coverage of that contract to almost 100% (there's a conditional branch that I can't trigger, and that maybe is not reachable<sup>1</sup>). Still, I'd like to add some other tests to check that the ERC780 claim is registered (or deleted, when unregistering). I may create another PR for that.

I also moved all the eslint stuff to the root of the project, so that the tests are also linted. I wanted to do this because this PR involved a lot of copying and pasting that was very error-prone, and having the linter feedback was extremely useful for that.

I also added a [`.editorconfig`](http://editorconfig.org/) file because I was tired of changing the indent width to 4 in my editor.

I know this is a lot of boring code to review. Besides checking the scenarios, something that can be more useful is to insert "bugs" in the contract and make sure that some test fails after that. For example, removing `require`s or replacing `if`s conditions with a literal `true` or `false`. I did a little of this, but of course the combinations are endless (it would be nice to have a [mutators](https://stryker-mutator.io/) library for solidity).

---

1. `userAddressConfirmed` has an `if (keccakIdentifier = 0x0)` that never enters. I think it's because the method throws if the index is out of bounds, instead of getting an empty value. I don't know why happens, I thought solidity had a sort of null pattern all the way down in arrays and structs.