### PR TITLE
(Fix) Handle locked sessions

### DIFF
--- a/web-dapp/controllers/notifyRegTx.js
+++ b/web-dapp/controllers/notifyRegTx.js
@@ -150,6 +150,11 @@ const removeUsedSessionKey = (opts, prelog) => {
         });
 };
 
+const unlockSession = (sessionKey, prelog) => {
+    logger.log(`${prelog} unlocking session: ${sessionKey}`);
+    return db.unlock(sessionKey);
+};
+
 module.exports = {
     validateData,
     normalizeData,
@@ -158,4 +163,5 @@ module.exports = {
     getAddressByBN,
     createPostCard,
     removeUsedSessionKey,
+    unlockSession,
 };

--- a/web-dapp/routes/notify_reg_tx.js
+++ b/web-dapp/routes/notify_reg_tx.js
@@ -43,7 +43,15 @@ module.exports = () => {
             })
             .catch(error => {
                 logger.error(`${prelog} ${error.msg}`);
-                return sendResponse(res, { ok: false, err: error.msg });
+                return notifyRegTxController
+                    .unlockSession(sessionKey, prelog)
+                    .then(
+                        () => {},
+                        () => logger.error(`${prelog} Could not unlock key ${sessionKey}`)
+                    )
+                    .then(() => {
+                        return sendResponse(res, { ok: false, err: error.msg });
+                    });
             });
     });
 

--- a/web-dapp/server-lib/session-stores/memory.js
+++ b/web-dapp/server-lib/session-stores/memory.js
@@ -25,6 +25,11 @@ module.exports = function () {
                 return resolve(db[k1(k)]);
             });
         },
+        unlock: (k) => {
+            db[k] = db[k1(k)];
+            delete db[k1(k)];
+            return Promise.resolve();
+        },
         unset: (k) => {
             delete db[k1(k)];
             return new Promise((resolve) => {

--- a/web-dapp/server-lib/session-stores/redis.js
+++ b/web-dapp/server-lib/session-stores/redis.js
@@ -55,6 +55,15 @@ module.exports = function () {
                 });
             });
         },
+        unlock: (k) => {
+            return new Promise((resolve, reject) => {
+                client.rename(k1(k), k, (err, res) => {
+                    if (err) return reject(err);
+
+                    resolve(res);
+                });
+            });
+        },
         get: (k) => {
             return new Promise((resolve, reject) => {
                 client.get(k, (err, v) => {

--- a/web-dapp/test/server/notify_reg_tx.spec.js
+++ b/web-dapp/test/server/notify_reg_tx.spec.js
@@ -33,6 +33,7 @@ jest.mock('../../controllers/notifyRegTx', () => ({
     getAddressByBN: jest.fn(() => Promise.resolve('0x1aa2d288d03d8397c193d2327ee7a7443d4ec3a3')),
     createPostCard: jest.fn(() => Promise.resolve({ postcard: 'PostCard' })),
     removeUsedSessionKey: jest.fn(() => Promise.resolve({ ok: true, result: { postcard: 'PostCard' } })),
+    unlockSession: jest.fn(() => Promise.resolve()),
 }));
 
 describe('notify_reg_tx', () => {


### PR DESCRIPTION
Closes #170.

This PR does two things:

- It unlocks the key if something fails in `notify_reg_tx`
- It unlocks all keys (in redis) on startup. Keys in memory are lost, of course, so there's nothing we can do there.