### PR TITLE
(Refactor) Return 200 status on responses with errors

### DIFF
--- a/web-dapp/server-lib/send_response.js
+++ b/web-dapp/server-lib/send_response.js
@@ -6,9 +6,7 @@ function send_response(res, obj) {
         obj.x_id = res.req.x_id;
     }
     logger.log('[response] (' + res.req.logPrfx + ') ' + JSON.stringify(obj));
-    const status = (obj.ok) ? 200 : 400;
-    return res.status(status)
-        .json(obj);
+    return res.json(obj);
 }
 
 module.exports = send_response;


### PR DESCRIPTION
- **What is it?** (leave one option)
    * `(Refactor)` of existing code (no functionality change)

When there is an error during workflow execution that is caught and processed by the server, server should return HTTP 200 code. It also makes UI error messages more readable. At the present moment it returns 400 if `response.ok == false`.

It first appeared in https://github.com/poanetwork/poa-popa/pull/80#discussion-diff-175150603R9 but somehow got merged anyway. Tests are passing because tests part was not merged and they don't rely on status code.

- **Does it close any open issues?**
Relates to #176 
