### PR TITLE
(Refactor) License from package.json should reference LICENSE

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "proof-of-address",
   "version": "1.0.0",
   "description": "Smart contract and DApp by poa.network to create proof of a physical address",
-  "license": "SEE LICENSE IN LICENSE",
+  "license": "GPL-3.0",
   "main": "server.js",
   "scripts": {
     "build": "npm run build --prefix web-dapp",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "proof-of-address",
   "version": "1.0.0",
   "description": "Smart contract and DApp by poa.network to create proof of a physical address",
-  "license": "MIT",
+  "license": "SEE LICENSE IN LICENSE",
   "main": "server.js",
   "scripts": {
     "build": "npm run build --prefix web-dapp",


### PR DESCRIPTION
- **What is it?** (leave one option)
    * `(Refactor)` of existing code (no functionality change)

- **What was the root cause of the problem originally / what feature was missing?**
License from package.json (MIT) does not match license from LICENSE file (GPLv3)

- **How does this pull request solve it (in broad terms)?**
Make package.json reference LICENSE file

- **Does it close any open issues?**
Closes #194  

